### PR TITLE
Fixing a major error with PEAR::isError() and PHP 5.3.7+

### DIFF
--- a/PEAR.php
+++ b/PEAR.php
@@ -249,6 +249,9 @@ class PEAR
      */
     function isError($data, $code = null)
     {
+        if (!is_object($data)) {
+             return false;
+        }
         if (!is_a($data, 'PEAR_Error')) {
             return false;
         }


### PR DESCRIPTION
is_a() now triggers an autoload for the class it's a string, so PEAR::isError($data) where $data is a string causes an autoload/class not found error. 
