### PR TITLE
Fix issue with php-cgi still being the interpreter in --CLEAN-- with tests using php-cgi

### DIFF
--- a/PEAR/RunTest.php
+++ b/PEAR/RunTest.php
@@ -275,10 +275,8 @@ class PEAR_RunTest
      */
     function run($file, $ini_settings_cmd_line = array(), $test_number = 1)
     {
-        if (isset($this->_savephp)) {
-            $this->_php = $this->_savephp;
-            unset($this->_savephp);
-        }
+        $this->_restorePHPBinary();
+
         if (empty($this->_options['cgi'])) {
             // try to see if php-cgi is in the path
             $res = $this->system_with_timeout('php-cgi -v');
@@ -345,7 +343,7 @@ class PEAR_RunTest
                 }
                 return 'SKIPPED';
             }
-            $this->_savephp = $this->_php;
+            $this->_savePHPBinary();
             $this->_php = $this->_options['cgi'];
         }
 
@@ -498,8 +496,6 @@ class PEAR_RunTest
         }
         chdir($cwd); // in case the test moves us around
 
-        $this->_testCleanup($section_text, $temp_clean);
-
         /* when using CGI, strip the headers from the output */
         $output = $this->_stripHeadersCGI($output);
 
@@ -520,6 +516,9 @@ class PEAR_RunTest
                 $output .= "\n====EXPECTHEADERS FAILURE====:\n$changed";
             }
         }
+
+        $this->_testCleanup($section_text, $temp_clean);
+
         // Does the output match what is expected?
         do {
             if (isset($section_text['EXPECTF']) || isset($section_text['EXPECTREGEX'])) {
@@ -958,6 +957,8 @@ $text
     function _testCleanup($section_text, $temp_clean)
     {
         if ($section_text['CLEAN']) {
+            $this->_restorePHPBinary();
+
             // perform test cleanup
             $this->save_text($temp_clean, $section_text['CLEAN']);
             $output = $this->system_with_timeout("$this->_php \"$temp_clean\"  2>&1");
@@ -967,6 +968,20 @@ $text
             if (file_exists($temp_clean)) {
                 unlink($temp_clean);
             }
+        }
+    }
+
+    function _savePHPBinary()
+    {
+        $this->_savephp = $this->_php;
+    }
+
+    function _restorePHPBinary()
+    {
+        if (isset($this->_savephp))
+        {
+            $this->_php = $this->_savephp;
+            unset($this->_savephp);
         }
     }
 }


### PR DESCRIPTION
This commit fixes an issue with RunTest not resetting the interpreter 
before running the --CLEAN-- section after running a test that needs
the php-cgi binary. Without this patch the cgi binary will output its headers, making RunTest barf on the output in the --CLEAN-- section.

The commit also moves the save / restore feature of which binary to use to two dedicated functions, to allow for improved reuse.

A simple test, not-perfect test is available in 7899b669a910a080668b43b9d6414724a56fc47f.

I'm not sure about how to implement the test to correctly do PASS/FAIL as it's dependent on the output of the test runner itself. One possibility is to implement a state / list of errors that'll be set if the --CLEAN-- section produces errors.
