### PR TITLE
metadata relocation

### DIFF
--- a/PEAR/Command/Install.php
+++ b/PEAR/Command/Install.php
@@ -556,7 +556,13 @@ Run post-installation scripts in package <package>, if any exist.
             $packrootphp_dir = $this->installer->_prependPath(
                 $this->config->get('php_dir', null, 'pear.php.net'),
                 $options['packagingroot']);
-            $instreg = new PEAR_Registry($packrootphp_dir); // other instreg!
+            $metadata_dir = $this->config->get('metadata_dir', null, 'pear.php.net');
+            if ($metadata_dir) {
+                $metadata_dir = $this->installer->_prependPath(
+                    $metadata_dir,
+                    $options['packagingroot']);
+            }
+            $instreg = new PEAR_Registry($packrootphp_dir, false, false, $metadata_dir); // other instreg!
 
             if ($this->config->get('verbose') > 2) {
                 $this->ui->outputData('using package root: ' . $options['packagingroot']);

--- a/PEAR/Config.php
+++ b/PEAR/Config.php
@@ -87,6 +87,13 @@ if (getenv('PHP_PEAR_INSTALL_DIR')) {
     }
 }
 
+// Default for metadata_dir
+if (getenv('PHP_PEAR_METADATA_DIR')) {
+    define('PEAR_CONFIG_DEFAULT_METADATA_DIR', getenv('PHP_PEAR_METADATA_DIR'));
+} else {
+    define('PEAR_CONFIG_DEFAULT_METADATA_DIR', '');
+}
+
 // Default for ext_dir
 if (getenv('PHP_PEAR_EXTENSION_DIR')) {
     define('PEAR_CONFIG_DEFAULT_EXT_DIR', getenv('PHP_PEAR_EXTENSION_DIR'));
@@ -398,6 +405,13 @@ class PEAR_Config extends PEAR
             'prompt' => 'PEAR directory',
             'group' => 'File Locations',
             ),
+        'metadata_dir' => array(
+            'type' => 'directory',
+            'default' => PEAR_CONFIG_DEFAULT_METADATA_DIR,
+            'doc' => 'directory where metadata files are installed (registry, filemap, channels, ...)',
+            'prompt' => 'PEAR metadata directory',
+            'group' => 'File Locations',
+            ),
         'ext_dir' => array(
             'type' => 'directory',
             'default' => PEAR_CONFIG_DEFAULT_EXT_DIR,
@@ -647,7 +661,9 @@ class PEAR_Config extends PEAR
             $this->configuration['default'][$key] = $info['default'];
         }
 
-        $this->_registry['default'] = &new PEAR_Registry($this->configuration['default']['php_dir']);
+        $this->_registry['default'] = &new PEAR_Registry(
+            $this->configuration['default']['php_dir'], false, false,
+            $this->configuration['default']['metadata_dir']);
         $this->_registry['default']->setConfig($this, false);
         $this->_regInitialized['default'] = false;
         //$GLOBALS['_PEAR_Config_instance'] = &$this;
@@ -754,7 +770,9 @@ class PEAR_Config extends PEAR
         $this->configuration[$layer] = $data;
         $this->_setupChannels();
         if (!$this->_noRegistry && ($phpdir = $this->get('php_dir', $layer, 'pear.php.net'))) {
-            $this->_registry[$layer] = &new PEAR_Registry($phpdir);
+            $this->_registry[$layer] = &new PEAR_Registry(
+                $phpdir, false, false,
+                $this->get('metadata_dir', $layer, 'pear.php.net'));
             $this->_registry[$layer]->setConfig($this, false);
             $this->_regInitialized[$layer] = false;
         } else {
@@ -911,7 +929,9 @@ class PEAR_Config extends PEAR
 
         $this->_setupChannels();
         if (!$this->_noRegistry && ($phpdir = $this->get('php_dir', $layer, 'pear.php.net'))) {
-            $this->_registry[$layer] = &new PEAR_Registry($phpdir);
+            $this->_registry[$layer] = &new PEAR_Registry(
+                $phpdir, false, false,
+                $this->get('metadata_dir', $layer, 'pear.php.net'));
             $this->_registry[$layer]->setConfig($this, false);
             $this->_regInitialized[$layer] = false;
         } else {
@@ -1604,7 +1624,9 @@ class PEAR_Config extends PEAR
 
                 if (!is_object($this->_registry[$layer])) {
                     if ($phpdir = $this->get('php_dir', $layer, 'pear.php.net')) {
-                        $this->_registry[$layer] = &new PEAR_Registry($phpdir);
+                        $this->_registry[$layer] = &new PEAR_Registry(
+                            $phpdir, false, false,
+                            $this->get('metadata_dir', $layer, 'pear.php.net'));
                         $this->_registry[$layer]->setConfig($this, false);
                         $this->_regInitialized[$layer] = false;
                     } else {
@@ -2087,8 +2109,9 @@ class PEAR_Config extends PEAR
                 if ($layer == 'ftp' || !isset($this->_registry[$layer])) {
                     continue;
                 }
-                $this->_registry[$layer] =
-                    &new PEAR_Registry($this->get('php_dir', $layer, 'pear.php.net'));
+                $this->_registry[$layer] = &new PEAR_Registry(
+                    $this->get('php_dir', $layer, 'pear.php.net'), false, false,
+                    $this->get('metadata_dir', $layer, 'pear.php.net'));
                 $this->_registry[$layer]->setConfig($this, false);
                 $this->_regInitialized[$layer] = false;
             }

--- a/PEAR/DependencyDB.php
+++ b/PEAR/DependencyDB.php
@@ -122,8 +122,11 @@ class PEAR_DependencyDB
 
         $this->_registry = &$this->_config->getRegistry();
         if (!$depdb) {
-            $this->_depdb = $this->_config->get('php_dir', null, 'pear.php.net') .
-                DIRECTORY_SEPARATOR . '.depdb';
+            $dir = $this->_config->get('metadata_dir', null, 'pear.php.net');
+            if (!$dir) {
+                $dir = $this->_config->get('php_dir', null, 'pear.php.net');
+            }
+            $this->_depdb =  $dir . DIRECTORY_SEPARATOR . '.depdb';
         } else {
             $this->_depdb = $depdb;
         }

--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -1123,15 +1123,6 @@ class PEAR_Installer extends PEAR_Downloader
 
         $name    = $pkg->getName();
         $channel = $pkg->getChannel();
-        if (isset($this->_options['packagingroot'])) {
-            $regdir = $this->_prependPath(
-                $this->config->get('php_dir', null, 'pear.php.net'),
-                $this->_options['packagingroot']);
-
-            $packrootphp_dir = $this->_prependPath(
-                $this->config->get('php_dir', null, $channel),
-                $this->_options['packagingroot']);
-        }
 
         if (isset($options['installroot'])) {
             $this->config->setInstallRoot($options['installroot']);
@@ -1143,7 +1134,21 @@ class PEAR_Installer extends PEAR_Downloader
             $this->config->setInstallRoot(false);
             $this->_registry = &$this->config->getRegistry();
             if (isset($this->_options['packagingroot'])) {
-                $installregistry = &new PEAR_Registry($regdir);
+                $regdir = $this->_prependPath(
+                    $this->config->get('php_dir', null, 'pear.php.net'),
+                    $this->_options['packagingroot']);
+
+                $metadata_dir = $this->config->get('metadata_dir', null, 'pear.php.net');
+                if ($metadata_dir) {
+                    $metadata_dir = $this->_prependPath(
+                        $metadata_dir,
+                        $this->_options['packagingroot']);
+                }
+                $packrootphp_dir = $this->_prependPath(
+                    $this->config->get('php_dir', null, $channel),
+                    $this->_options['packagingroot']);
+
+                $installregistry = &new PEAR_Registry($regdir, false, false, $metadata_dir);
                 if (!$installregistry->channelExists($channel, true)) {
                     // we need to fake a channel-discover of this channel
                     $chanobj = $this->_registry->getChannel($channel, true);

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -132,23 +132,26 @@ class PEAR_Registry extends PEAR
      * @access public
      */
     function PEAR_Registry($pear_install_dir = PEAR_INSTALL_DIR, $pear_channel = false,
-                           $pecl_channel = false)
+                           $pecl_channel = false, $pear_metadata_dir = '')
     {
         parent::PEAR();
-        $this->setInstallDir($pear_install_dir);
+        $this->setInstallDir($pear_install_dir, $pear_metadata_dir);
         $this->_pearChannel = $pear_channel;
         $this->_peclChannel = $pecl_channel;
         $this->_config      = false;
     }
 
-    function setInstallDir($pear_install_dir = PEAR_INSTALL_DIR)
+    function setInstallDir($pear_install_dir = PEAR_INSTALL_DIR, $pear_metadata_dir = '')
     {
         $ds = DIRECTORY_SEPARATOR;
         $this->install_dir = $pear_install_dir;
-        $this->channelsdir = $pear_install_dir.$ds.'.channels';
-        $this->statedir    = $pear_install_dir.$ds.'.registry';
-        $this->filemap     = $pear_install_dir.$ds.'.filemap';
-        $this->lockfile    = $pear_install_dir.$ds.'.lock';
+        if (!$pear_metadata_dir) {
+            $pear_metadata_dir = $pear_install_dir;
+        }
+        $this->channelsdir = $pear_metadata_dir.$ds.'.channels';
+        $this->statedir    = $pear_metadata_dir.$ds.'.registry';
+        $this->filemap     = $pear_metadata_dir.$ds.'.filemap';
+        $this->lockfile    = $pear_metadata_dir.$ds.'.lock';
     }
 
     function hasWriteAccess()
@@ -181,7 +184,7 @@ class PEAR_Registry extends PEAR
     {
         $this->_config = &$config;
         if ($resetInstallDir) {
-            $this->setInstallDir($config->get('php_dir'));
+            $this->setInstallDir($config->get('php_dir'), $config->get('metadata_dir'));
         }
     }
 
@@ -328,9 +331,9 @@ class PEAR_Registry extends PEAR
                 $this->_dependencyDB = &PEAR_DependencyDB::singleton($this->_config);
                 if (PEAR::isError($this->_dependencyDB)) {
                     // attempt to recover by removing the dep db
-                    if (file_exists($this->_config->get('php_dir', null, 'pear.php.net') .
+                    if (file_exists($this->_config->get('metadata_dir', null, 'pear.php.net') .
                         DIRECTORY_SEPARATOR . '.depdb')) {
-                        @unlink($this->_config->get('php_dir', null, 'pear.php.net') .
+                        @unlink($this->_config->get('metadata_dir', null, 'pear.php.net') .
                             DIRECTORY_SEPARATOR . '.depdb');
                     }
 

--- a/install-pear.php
+++ b/install-pear.php
@@ -72,6 +72,9 @@ for ($i = 0; $i < sizeof($argv); $i++) {
     } elseif ($arg == '-o' || $arg == '--download') {
         $download_dir = $argv[$i+1];
         $i++;
+    } elseif ($arg == '-m' || $arg == '--metadata') {
+        $metadata_dir = $argv[$i+1];
+        $i++;
     } elseif ($arg == '-t' || $arg == '--temp') {
         $temp_dir = $argv[$i+1];
         $i++;
@@ -159,6 +162,10 @@ if (!empty($test_dir)) {
 if (!empty($with_dir)) {
     $ds = DIRECTORY_SEPARATOR;
     $config->set('php_dir', $with_dir, 'default');
+    // Metadata
+    if (!empty($metadata_dir)) {
+        $config->set('metadata_dir', $metadata_dir, 'default');
+    }
     if (empty($doc_dir)) {
         $config->set('doc_dir', $with_dir . $ds . 'doc', 'default');
     }
@@ -230,7 +237,7 @@ $options['upgrade'] = true;
 $install_root = getenv('INSTALL_ROOT');
 if (!empty($install_root)) {
     $options['packagingroot'] = $install_root;
-    $reg = &new PEAR_Registry($options['packagingroot']);
+    $reg = &new PEAR_Registry($options['packagingroot'], false, false, $metadata_dir);
 } else {
     $reg = $config->getRegistry('default');
 }


### PR DESCRIPTION
This patch introduce the new metadata dir to allow relocation of .registry, .channels, .filemap and .depdb and to be compliant with FHS.

Ex : 
- script in /usr/share/pear
- metadata in /var/lib/pear

Note : default value is empty, which means, use same php_dir. This should manage smooth upgrade from previous version, with same configuration file.

This allow avoid to have unwanted stuff in the default include_path.

See http://article.gmane.org/gmane.comp.php.pear.devel/50455
