### PR TITLE
use absolute path for zend_extensions

### DIFF
--- a/PEAR/Command/Install.php
+++ b/PEAR/Command/Install.php
@@ -785,8 +785,7 @@ Run post-installation scripts in package <package>, if any exist.
                             }
                             if ($exttype == 'zend_extension') {
                                 $extpath = $atts['installed_as'];
-                            }
-                            else {
+                            } else {
                                 $extpath = $pinfo[1]['basename'];
                             }
                             $extrainfo[] = 'You should add "' . $exttype . '=' .


### PR DESCRIPTION
The pear installer notifies the user that they should load the newly installed pecl extension via php.ini, but for zend_extensions the absolute url has to be specified, see http://www.php.net/manual/en/ini.core.php#ini.zend-extension
(basically extension_dir is not used for zend_extensions)
