### PR TITLE
[fix] PHP Deprecated warnings to work with php_beautifier

### DIFF
--- a/PEAR/Config.php
+++ b/PEAR/Config.php
@@ -680,7 +680,7 @@ class PEAR_Config extends PEAR
             $this->configuration['default'][$key] = $info['default'];
         }
 
-        $this->_registry['default'] = &new PEAR_Registry(
+        $this->_registry['default'] = new PEAR_Registry(
             $this->configuration['default']['php_dir'], false, false,
             $this->configuration['default']['metadata_dir']);
         $this->_registry['default']->setConfig($this, false);
@@ -731,7 +731,7 @@ class PEAR_Config extends PEAR
             return $GLOBALS['_PEAR_Config_instance'];
         }
 
-        $t_conf = &new PEAR_Config($user_file, $system_file, false, $strict);
+        $t_conf = new PEAR_Config($user_file, $system_file, false, $strict);
         if ($t_conf->_errorsFound > 0) {
              return $t_conf->lastError;
         }
@@ -791,7 +791,7 @@ class PEAR_Config extends PEAR
         $this->configuration[$layer] = $data;
         $this->_setupChannels();
         if (!$this->_noRegistry && ($phpdir = $this->get('php_dir', $layer, 'pear.php.net'))) {
-            $this->_registry[$layer] = &new PEAR_Registry(
+            $this->_registry[$layer] = new PEAR_Registry(
                 $phpdir, false, false,
                 $this->get('metadata_dir', $layer, 'pear.php.net'));
             $this->_registry[$layer]->setConfig($this, false);
@@ -822,7 +822,7 @@ class PEAR_Config extends PEAR
                 return PEAR::raiseError('PEAR_RemoteInstaller must be installed to use remote config');
             }
 
-            $this->_ftp = &new PEAR_FTP;
+            $this->_ftp = new PEAR_FTP;
             $this->_ftp->pushErrorHandling(PEAR_ERROR_RETURN);
             $e = $this->_ftp->init($path);
             if (PEAR::isError($e)) {
@@ -950,7 +950,7 @@ class PEAR_Config extends PEAR
 
         $this->_setupChannels();
         if (!$this->_noRegistry && ($phpdir = $this->get('php_dir', $layer, 'pear.php.net'))) {
-            $this->_registry[$layer] = &new PEAR_Registry(
+            $this->_registry[$layer] = new PEAR_Registry(
                 $phpdir, false, false,
                 $this->get('metadata_dir', $layer, 'pear.php.net'));
             $this->_registry[$layer]->setConfig($this, false);
@@ -1615,7 +1615,7 @@ class PEAR_Config extends PEAR
         if ($key == 'php_dir' && !$this->_noRegistry) {
             if (!isset($this->_registry[$layer]) ||
                   $value != $this->_registry[$layer]->install_dir) {
-                $this->_registry[$layer] = &new PEAR_Registry($value);
+                $this->_registry[$layer] = new PEAR_Registry($value);
                 $this->_regInitialized[$layer] = false;
                 $this->_registry[$layer]->setConfig($this, false);
             }
@@ -1645,7 +1645,7 @@ class PEAR_Config extends PEAR
 
                 if (!is_object($this->_registry[$layer])) {
                     if ($phpdir = $this->get('php_dir', $layer, 'pear.php.net')) {
-                        $this->_registry[$layer] = &new PEAR_Registry(
+                        $this->_registry[$layer] = new PEAR_Registry(
                             $phpdir, false, false,
                             $this->get('metadata_dir', $layer, 'pear.php.net'));
                         $this->_registry[$layer]->setConfig($this, false);
@@ -2078,7 +2078,7 @@ class PEAR_Config extends PEAR
             require_once 'PEAR/REST/' . $version . '.php';
         }
 
-        $remote = &new $class($this, $options);
+        $remote = new $class($this, $options);
         return $remote;
     }
 
@@ -2130,7 +2130,7 @@ class PEAR_Config extends PEAR
                 if ($layer == 'ftp' || !isset($this->_registry[$layer])) {
                     continue;
                 }
-                $this->_registry[$layer] = &new PEAR_Registry(
+                $this->_registry[$layer] = new PEAR_Registry(
                     $this->get('php_dir', $layer, 'pear.php.net'), false, false,
                     $this->get('metadata_dir', $layer, 'pear.php.net'));
                 $this->_registry[$layer]->setConfig($this, false);

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -322,7 +322,7 @@ class PEAR_Registry extends PEAR
                 $initializing = true;
                 if (!$this->_config) { // never used?
                     $file = OS_WINDOWS ? 'pear.ini' : '.pearrc';
-                    $this->_config = &new PEAR_Config($this->statedir . DIRECTORY_SEPARATOR .
+                    $this->_config = new PEAR_Config($this->statedir . DIRECTORY_SEPARATOR .
                         $file);
                     $this->_config->setRegistry($this);
                     $this->_config->set('php_dir', $this->install_dir);
@@ -1450,7 +1450,7 @@ class PEAR_Registry extends PEAR
 
         $a = $this->_config;
         if (!$a) {
-            $this->_config = &new PEAR_Config;
+            $this->_config = new PEAR_Config;
             $this->_config->set('php_dir', $this->statedir);
         }
 
@@ -1458,7 +1458,7 @@ class PEAR_Registry extends PEAR
             require_once 'PEAR/PackageFile.php';
         }
 
-        $pkg = &new PEAR_PackageFile($this->_config);
+        $pkg = new PEAR_PackageFile($this->_config);
         $pf = &$pkg->fromArray($info);
         return $pf;
     }


### PR DESCRIPTION
- I have tried to fix PEAR issue with php beautifier.
- When trying to format code using beautifier there below error is shown in Lunux ubuntu with Php 5.3.10-1ubuntu3.6

```
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Config.php on line 650
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Config.php on line 697
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Config.php on line 757
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Config.php on line 786
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Config.php on line 914
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Config.php on line 1577
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Config.php on line 1607
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Config.php on line 2038
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Config.php on line 2091
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Registry.php on line 322
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Registry.php on line 1450
PHP Deprecated:  Assigning the return value of new by reference is deprecated in /home/gunjan/pear/share/pear/PEAR/Registry.php on line 1458
```
