### PR TITLE
Resolves Bug# 20203

### DIFF
--- a/PEAR/REST.php
+++ b/PEAR/REST.php
@@ -133,6 +133,7 @@ class PEAR_REST
             $content_type = $content_type[0];
             switch ($content_type) {
                 case 'text/xml' :
+                case 'text/xml; charset=utf-8' :
                 case 'application/xml' :
                 case 'text/plain' :
                     if ($content_type === 'text/plain') {


### PR DESCRIPTION
Github in their XML files includes a charset=utf-8 in the $headers['content-type'] variable, this accounts for that.
