### PR TITLE
Fix for bogus "symlink attack" error on Windows (bug #18834)

### DIFF
--- a/PEAR/REST.php
+++ b/PEAR/REST.php
@@ -275,19 +275,24 @@ class PEAR_REST
                 return PEAR::raiseError("Could not write $file.");
             }
         } else { // update file
-            $cachefile_lstat = lstat($file);
-            $cachefile_fp = @fopen($file, 'wb');
+            $cachefile_fp = @fopen($file, 'r+b'); // do not truncate file
             if (!$cachefile_fp) {
                 return PEAR::raiseError("Could not open $file for writing.");
             }
 
-            $cachefile_fstat = fstat($cachefile_fp);
-            if (
-              $cachefile_lstat['mode'] == $cachefile_fstat['mode'] &&
-              $cachefile_lstat['ino']  == $cachefile_fstat['ino'] &&
-              $cachefile_lstat['dev']  == $cachefile_fstat['dev'] &&
-              $cachefile_fstat['nlink'] === 1
-            ) {
+            if (OS_WINDOWS) {
+                $not_symlink     = !is_link($file); // see bug #18834
+            } else {
+                $cachefile_lstat = lstat($file);
+                $cachefile_fstat = fstat($cachefile_fp);
+                $not_symlink     = $cachefile_lstat['mode'] == $cachefile_fstat['mode']
+                                   && $cachefile_lstat['ino']  == $cachefile_fstat['ino']
+                                   && $cachefile_lstat['dev']  == $cachefile_fstat['dev']
+                                   && $cachefile_fstat['nlink'] === 1;
+            }
+
+            if ($not_symlink) {
+                ftruncate($cachefile_fp, 0); // NOW truncate
                 if (fwrite($cachefile_fp, $contents, $len) < $len) {
                     fclose($cachefile_fp);
                     return PEAR::raiseError("Could not write $file.");

--- a/tests/PEAR_REST/bug18056.phpt
+++ b/tests/PEAR_REST/bug18056.phpt
@@ -11,6 +11,7 @@ if (strtolower(substr(PHP_OS, 0, 3)) == 'win'
 }
 --FILE--
 <?php
+require_once dirname(dirname(__FILE__)) . '/phpt_test.php.inc';
 require_once 'PEAR/REST.php';
 
 PEAR::staticPushErrorHandling(PEAR_ERROR_PRINT);


### PR DESCRIPTION
Also another unpleasant issue is fixed: if the cache file was actually a symlink, it was truncated (due to opening in 'wb' mode) **before** a check for symlink was made.

A test is available as well, unfortunately it needs either Admin rights or updated security policy to run on Windows.
