### PR TITLE
Fix for missing DIRECTORY_SEPARATOR in message

### DIFF
--- a/PEAR/Start/CLI.php
+++ b/PEAR/Start/CLI.php
@@ -600,7 +600,7 @@ php.ini <$pathIni> include_path updated.
             echo "
 
 * WINDOWS ENVIRONMENT VARIABLES *
-For convenience, a REG file is available under {$this->prefix}PEAR_ENV.reg .
+For convenience, a REG file is available under {$this->prefix}" . DIRECTORY_SEPARATOR . "PEAR_ENV.reg .
 This file creates ENV variables for the current user.
 
 Double-click this file to add it to the current user registry.


### PR DESCRIPTION
- WINDOWS ENVIRONMENT VARIABLES *
  For convenience, a REG file is available under C:\wamp\bin\php\php5.5.12PEAR_ENV.reg .
  This file creates ENV variables for the current user.

Double-click this file to add it to the current user registry.
