### PR TITLE
avoid overwriting include path

### DIFF
--- a/scripts/pearcmd.php
+++ b/scripts/pearcmd.php
@@ -28,7 +28,7 @@ define('PEAR_IGNORE_BACKTRACE', 1);
 //the space is needed for windows include paths with trailing backslash
 // http://pear.php.net/bugs/bug.php?id=19482
 if ('@include_path@ ' != '@'.'include_path'.'@ ') {
-    ini_set('include_path', trim('@include_path@ '));
+    ini_set('include_path', trim('@include_path@ '). PATH_SEPARATOR .  get_include_path());
     $raw = false;
 } else {
     // this is a raw, uninstalled pear, either a cvs checkout, or php distro

--- a/scripts/peclcmd.php
+++ b/scripts/peclcmd.php
@@ -22,7 +22,7 @@
 //the space is needed for windows include paths with trailing backslash
 // http://pear.php.net/bugs/bug.php?id=19482
 if ('@include_path@ ' != '@'.'include_path'.'@ ') {
-    ini_set('include_path', trim('@include_path@ '));
+    ini_set('include_path', trim('@include_path@ '). PATH_SEPARATOR .  get_include_path());
     $raw = false;
 } else {
     // this is a raw, uninstalled pear, either a cvs checkout, or php distro


### PR DESCRIPTION
- fixes pear bug http://pear.php.net/bugs/bug.php?id=17045
- refs e115fc9, de36f63, 51c697a, 9c19304
- solves installation via composer where other pear packaegs are _NOT_
  installed to same include path as PEAR package itself
