### PR TITLE
Fix/Remove PHP4 style constructors.

### DIFF
--- a/OS/Guess.php
+++ b/OS/Guess.php
@@ -99,7 +99,7 @@ class OS_Guess
     var $release;
     var $extra;
 
-    function OS_Guess($uname = null)
+    function __construct($uname = null)
     {
         list($this->sysname,
              $this->release,

--- a/PEAR.php
+++ b/PEAR.php
@@ -89,64 +89,64 @@ class PEAR
     /**
      * Whether to enable internal debug messages.
      *
-     * @var     bool
+     * @var bool
      * @access  private
      */
-    var $_debug = false;
+    public $_debug = false;
 
     /**
      * Default error mode for this object.
      *
-     * @var     int
+     * @var int
      * @access  private
      */
-    var $_default_error_mode = null;
+    public $_default_error_mode = null;
 
     /**
      * Default error options used for this object when error mode
      * is PEAR_ERROR_TRIGGER.
      *
-     * @var     int
+     * @var int
      * @access  private
      */
-    var $_default_error_options = null;
+    public $_default_error_options = null;
 
     /**
      * Default error handler (callback) for this object, if error mode is
      * PEAR_ERROR_CALLBACK.
      *
-     * @var     string
+     * @var string
      * @access  private
      */
-    var $_default_error_handler = '';
+    public $_default_error_handler = '';
 
     /**
      * Which class to use for error objects.
      *
-     * @var     string
+     * @var string
      * @access  private
      */
-    var $_error_class = 'PEAR_Error';
+    public $_error_class = 'PEAR_Error';
 
     /**
      * An array of expected errors.
      *
-     * @var     array
+     * @var array
      * @access  private
      */
-    var $_expected_errors = array();
+    public $_expected_errors = array();
 
     /**
      * Constructor.  Registers this object in
      * $_PEAR_destructor_object_list for destructor emulation if a
      * destructor object exists.
      *
-     * @param string $error_class  (optional) which class to use for
-     *        error objects, defaults to PEAR_Error.
+     * @param  string $error_class (optional) which class to use for
+     *                             error objects, defaults to PEAR_Error.
      * @access public
      * @return void
      */
-    function PEAR($error_class = null)
+    public function PEAR($error_class = null)
     {
         $classname = strtolower(get_class($this));
         if ($this->_debug) {
@@ -184,25 +184,26 @@ class PEAR
      * @access public
      * @return void
      */
-    function _PEAR() {
+    public function _PEAR()
+    {
         if ($this->_debug) {
             printf("PEAR destructor called, class=%s\n", strtolower(get_class($this)));
         }
     }
 
     /**
-    * If you have a class that's mostly/entirely static, and you need static
-    * properties, you can use this method to simulate them. Eg. in your method(s)
-    * do this: $myVar = &PEAR::getStaticProperty('myclass', 'myVar');
-    * You MUST use a reference, or they will not persist!
-    *
-    * @access public
-    * @param  string $class  The calling classname, to prevent clashes
-    * @param  string $var    The variable to retrieve.
-    * @return mixed   A reference to the variable. If not set it will be
-    *                 auto initialised to NULL.
-    */
-    function &getStaticProperty($class, $var)
+     * If you have a class that's mostly/entirely static, and you need static
+     * properties, you can use this method to simulate them. Eg. in your method(s)
+     * do this: $myVar = &PEAR::getStaticProperty('myclass', 'myVar');
+     * You MUST use a reference, or they will not persist!
+     *
+     * @access public
+     * @param  string $class The calling classname, to prevent clashes
+     * @param  string $var   The variable to retrieve.
+     * @return mixed  A reference to the variable. If not set it will be
+     *                      auto initialised to NULL.
+     */
+    public function &getStaticProperty($class, $var)
     {
         static $properties;
         if (!isset($properties[$class])) {
@@ -217,15 +218,15 @@ class PEAR
     }
 
     /**
-    * Use this function to register a shutdown method for static
-    * classes.
-    *
-    * @access public
-    * @param  mixed $func  The function name (or array of class/method) to call
-    * @param  mixed $args  The arguments to pass to the function
-    * @return void
-    */
-    function registerShutdownFunc($func, $args = array())
+     * Use this function to register a shutdown method for static
+     * classes.
+     *
+     * @access public
+     * @param  mixed $func The function name (or array of class/method) to call
+     * @param  mixed $args The arguments to pass to the function
+     * @return void
+     */
+    public function registerShutdownFunc($func, $args = array())
     {
         // if we are called statically, there is a potential
         // that no shutdown func is registered.  Bug #6445
@@ -239,15 +240,15 @@ class PEAR
     /**
      * Tell whether a value is a PEAR error.
      *
-     * @param   mixed $data   the value to test
-     * @param   int   $code   if $data is an error object, return true
-     *                        only if $code is a string and
-     *                        $obj->getMessage() == $code or
-     *                        $code is an integer and $obj->getCode() == $code
+     * @param  mixed $data the value to test
+     * @param  int   $code if $data is an error object, return true
+     *                     only if $code is a string and
+     *                     $obj->getMessage() == $code or
+     *                     $code is an integer and $obj->getCode() == $code
      * @access  public
-     * @return  bool    true if parameter is an error
+     * @return bool  true if parameter is an error
      */
-    function isError($data, $code = null)
+    public function isError($data, $code = null)
     {
         if (!is_a($data, 'PEAR_Error')) {
             return false;
@@ -270,13 +271,13 @@ class PEAR
      * the default behaviour for that object.
      *
      * @param int $mode
-     *        One of PEAR_ERROR_RETURN, PEAR_ERROR_PRINT,
-     *        PEAR_ERROR_TRIGGER, PEAR_ERROR_DIE,
-     *        PEAR_ERROR_CALLBACK or PEAR_ERROR_EXCEPTION.
+     *                  One of PEAR_ERROR_RETURN, PEAR_ERROR_PRINT,
+     *                  PEAR_ERROR_TRIGGER, PEAR_ERROR_DIE,
+     *                  PEAR_ERROR_CALLBACK or PEAR_ERROR_EXCEPTION.
      *
      * @param mixed $options
-     *        When $mode is PEAR_ERROR_TRIGGER, this is the error level (one
-     *        of E_USER_NOTICE, E_USER_WARNING or E_USER_ERROR).
+     *                       When $mode is PEAR_ERROR_TRIGGER, this is the error level (one
+     *                       of E_USER_NOTICE, E_USER_WARNING or E_USER_ERROR).
      *
      *        When $mode is PEAR_ERROR_CALLBACK, this parameter is expected
      *        to be the callback function or method.  A callback
@@ -300,7 +301,7 @@ class PEAR
      *
      * @since PHP 4.0.5
      */
-    function setErrorHandling($mode = null, $options = null)
+    public function setErrorHandling($mode = null, $options = null)
     {
         if (isset($this) && is_a($this, 'PEAR')) {
             $setmode     = &$this->_default_error_mode;
@@ -349,16 +350,17 @@ class PEAR
      *
      * @param mixed $code a single error code or an array of error codes to expect
      *
-     * @return int     the new depth of the "expected errors" stack
+     * @return int the new depth of the "expected errors" stack
      * @access public
      */
-    function expectError($code = '*')
+    public function expectError($code = '*')
     {
         if (is_array($code)) {
             array_push($this->_expected_errors, $code);
         } else {
             array_push($this->_expected_errors, array($code));
         }
+
         return count($this->_expected_errors);
     }
 
@@ -366,9 +368,9 @@ class PEAR
      * This method pops one element off the expected error codes
      * stack.
      *
-     * @return array   the list of error codes that were popped
+     * @return array the list of error codes that were popped
      */
-    function popExpect()
+    public function popExpect()
     {
         return array_pop($this->_expected_errors);
     }
@@ -381,7 +383,7 @@ class PEAR
      * @access private
      * @since PHP 4.3.0
      */
-    function _checkDelExpect($error_code)
+    public function _checkDelExpect($error_code)
     {
         $deleted = false;
         foreach ($this->_expected_errors as $key => $error_array) {
@@ -408,7 +410,7 @@ class PEAR
      * @access public
      * @since PHP 4.3.0
      */
-    function delExpect($error_code)
+    public function delExpect($error_code)
     {
         $deleted = false;
         if ((is_array($error_code) && (0 != count($error_code)))) {
@@ -440,36 +442,36 @@ class PEAR
      *
      * @param mixed $message a text error message or a PEAR error object
      *
-     * @param int $code      a numeric error code (it is up to your class
+     * @param int $code a numeric error code (it is up to your class
      *                  to define these if you want to use codes)
      *
-     * @param int $mode      One of PEAR_ERROR_RETURN, PEAR_ERROR_PRINT,
+     * @param int $mode One of PEAR_ERROR_RETURN, PEAR_ERROR_PRINT,
      *                  PEAR_ERROR_TRIGGER, PEAR_ERROR_DIE,
      *                  PEAR_ERROR_CALLBACK, PEAR_ERROR_EXCEPTION.
      *
      * @param mixed $options If $mode is PEAR_ERROR_TRIGGER, this parameter
-     *                  specifies the PHP-internal error level (one of
-     *                  E_USER_NOTICE, E_USER_WARNING or E_USER_ERROR).
-     *                  If $mode is PEAR_ERROR_CALLBACK, this
-     *                  parameter specifies the callback function or
-     *                  method.  In other error modes this parameter
-     *                  is ignored.
+     *                       specifies the PHP-internal error level (one of
+     *                       E_USER_NOTICE, E_USER_WARNING or E_USER_ERROR).
+     *                       If $mode is PEAR_ERROR_CALLBACK, this
+     *                       parameter specifies the callback function or
+     *                       method.  In other error modes this parameter
+     *                       is ignored.
      *
      * @param string $userinfo If you need to pass along for example debug
-     *                  information, this parameter is meant for that.
+     *                         information, this parameter is meant for that.
      *
      * @param string $error_class The returned error object will be
-     *                  instantiated from this class, if specified.
+     *                            instantiated from this class, if specified.
      *
      * @param bool $skipmsg If true, raiseError will only pass error codes,
-     *                  the error message parameter will be dropped.
+     *                      the error message parameter will be dropped.
      *
      * @access public
-     * @return object   a PEAR error object
+     * @return object a PEAR error object
      * @see PEAR::setErrorHandling
      * @since PHP 4.0.5
      */
-    function &raiseError($message = null,
+    public function &raiseError($message = null,
                          $code = null,
                          $mode = null,
                          $options = null,
@@ -524,6 +526,7 @@ class PEAR
         if (intval(PHP_VERSION) < 5) {
             // little non-eval hack to fix bug #12147
             include 'PEAR/FixPHP5PEARWarnings.php';
+
             return $a;
         }
 
@@ -542,28 +545,30 @@ class PEAR
      *
      * @param mixed $message a text error message or a PEAR error object
      *
-     * @param int $code      a numeric error code (it is up to your class
+     * @param int $code a numeric error code (it is up to your class
      *                  to define these if you want to use codes)
      *
      * @param string $userinfo If you need to pass along for example debug
-     *                  information, this parameter is meant for that.
+     *                         information, this parameter is meant for that.
      *
      * @access public
-     * @return object   a PEAR error object
+     * @return object a PEAR error object
      * @see PEAR::raiseError
      */
-    function &throwError($message = null, $code = null, $userinfo = null)
+    public function &throwError($message = null, $code = null, $userinfo = null)
     {
         if (isset($this) && is_a($this, 'PEAR')) {
             $a = &$this->raiseError($message, $code, null, null, $userinfo);
+
             return $a;
         }
 
         $a = &PEAR::raiseError($message, $code, null, null, $userinfo);
+
         return $a;
     }
 
-    function staticPushErrorHandling($mode, $options = null)
+    public function staticPushErrorHandling($mode, $options = null)
     {
         $stack       = &$GLOBALS['_PEAR_error_handler_stack'];
         $def_mode    = &$GLOBALS['_PEAR_default_error_mode'];
@@ -595,10 +600,11 @@ class PEAR
                 break;
         }
         $stack[] = array($mode, $options);
+
         return true;
     }
 
-    function staticPopErrorHandling()
+    public function staticPopErrorHandling()
     {
         $stack = &$GLOBALS['_PEAR_error_handler_stack'];
         $setmode     = &$GLOBALS['_PEAR_default_error_mode'];
@@ -631,6 +637,7 @@ class PEAR
                 trigger_error("invalid error mode", E_USER_WARNING);
                 break;
         }
+
         return true;
     }
 
@@ -639,14 +646,14 @@ class PEAR
      * you can easily override the actual error handler for some code and restore
      * it later with popErrorHandling.
      *
-     * @param mixed $mode (same as setErrorHandling)
+     * @param mixed $mode    (same as setErrorHandling)
      * @param mixed $options (same as setErrorHandling)
      *
      * @return bool Always true
      *
      * @see PEAR::setErrorHandling
      */
-    function pushErrorHandling($mode, $options = null)
+    public function pushErrorHandling($mode, $options = null)
     {
         $stack = &$GLOBALS['_PEAR_error_handler_stack'];
         if (isset($this) && is_a($this, 'PEAR')) {
@@ -664,17 +671,18 @@ class PEAR
             PEAR::setErrorHandling($mode, $options);
         }
         $stack[] = array($mode, $options);
+
         return true;
     }
 
     /**
-    * Pop the last error handler used
-    *
-    * @return bool Always true
-    *
-    * @see PEAR::pushErrorHandling
-    */
-    function popErrorHandling()
+     * Pop the last error handler used
+     *
+     * @return bool Always true
+     *
+     * @see PEAR::pushErrorHandling
+     */
+    public function popErrorHandling()
     {
         $stack = &$GLOBALS['_PEAR_error_handler_stack'];
         array_pop($stack);
@@ -685,17 +693,18 @@ class PEAR
         } else {
             PEAR::setErrorHandling($mode, $options);
         }
+
         return true;
     }
 
     /**
-    * OS independent PHP extension load. Remember to take care
-    * on the correct extension name for case sensitive OSes.
-    *
-    * @param string $ext The extension name
-    * @return bool Success or not on the dl() call
-    */
-    function loadExtension($ext)
+     * OS independent PHP extension load. Remember to take care
+     * on the correct extension name for case sensitive OSes.
+     *
+     * @param  string $ext The extension name
+     * @return bool   Success or not on the dl() call
+     */
+    public function loadExtension($ext)
     {
         if (extension_loaded($ext)) {
             return true;
@@ -734,8 +743,7 @@ function _PEAR_call_destructors()
 {
     global $_PEAR_destructor_object_list;
     if (is_array($_PEAR_destructor_object_list) &&
-        sizeof($_PEAR_destructor_object_list))
-    {
+        sizeof($_PEAR_destructor_object_list)) {
         reset($_PEAR_destructor_object_list);
         if (PEAR_ZE2) {
             $destructLifoExists = PEAR5::getStaticProperty('PEAR', 'destructlifo');
@@ -795,35 +803,35 @@ function _PEAR_call_destructors()
  */
 class PEAR_Error
 {
-    var $error_message_prefix = '';
-    var $mode                 = PEAR_ERROR_RETURN;
-    var $level                = E_USER_NOTICE;
-    var $code                 = -1;
-    var $message              = '';
-    var $userinfo             = '';
-    var $backtrace            = null;
+    public $error_message_prefix = '';
+    public $mode                 = PEAR_ERROR_RETURN;
+    public $level                = E_USER_NOTICE;
+    public $code                 = -1;
+    public $message              = '';
+    public $userinfo             = '';
+    public $backtrace            = null;
 
     /**
      * PEAR_Error constructor
      *
-     * @param string $message  message
+     * @param string $message message
      *
-     * @param int $code     (optional) error code
+     * @param int $code (optional) error code
      *
-     * @param int $mode     (optional) error mode, one of: PEAR_ERROR_RETURN,
-     * PEAR_ERROR_PRINT, PEAR_ERROR_DIE, PEAR_ERROR_TRIGGER,
-     * PEAR_ERROR_CALLBACK or PEAR_ERROR_EXCEPTION
+     * @param int $mode (optional) error mode, one of: PEAR_ERROR_RETURN,
+     *                  PEAR_ERROR_PRINT, PEAR_ERROR_DIE, PEAR_ERROR_TRIGGER,
+     *                  PEAR_ERROR_CALLBACK or PEAR_ERROR_EXCEPTION
      *
-     * @param mixed $options   (optional) error level, _OR_ in the case of
-     * PEAR_ERROR_CALLBACK, the callback function or object/method
-     * tuple.
+     * @param mixed $options (optional) error level, _OR_ in the case of
+     *                       PEAR_ERROR_CALLBACK, the callback function or object/method
+     *                       tuple.
      *
      * @param string $userinfo (optional) additional user/debug info
      *
      * @access public
      *
      */
-    function PEAR_Error($message = 'unknown error', $code = null,
+    public function PEAR_Error($message = 'unknown error', $code = null,
                         $mode = null, $options = null, $userinfo = null)
     {
         if ($mode === null) {
@@ -902,7 +910,7 @@ class PEAR_Error
      * @return int error mode
      * @access public
      */
-    function getMode()
+    public function getMode()
     {
         return $this->mode;
     }
@@ -913,7 +921,7 @@ class PEAR_Error
      * @return mixed callback function or object/method array
      * @access public
      */
-    function getCallback()
+    public function getCallback()
     {
         return $this->callback;
     }
@@ -921,23 +929,23 @@ class PEAR_Error
     /**
      * Get the error message from an error object.
      *
-     * @return  string  full error message
+     * @return string full error message
      * @access public
      */
-    function getMessage()
+    public function getMessage()
     {
-        return ($this->error_message_prefix . $this->message);
+        return ($this->error_message_prefix.$this->message);
     }
 
-    /**
-     * Get error code from an error object
-     *
-     * @return int error code
-     * @access public
-     */
-     function getCode()
+     /**
+      * Get error code from an error object
+      *
+      * @return int error code
+      * @access public
+      */
+     public function getCode()
      {
-        return $this->code;
+         return $this->code;
      }
 
     /**
@@ -946,7 +954,7 @@ class PEAR_Error
      * @return string error/exception name (type)
      * @access public
      */
-    function getType()
+    public function getType()
     {
         return get_class($this);
     }
@@ -957,7 +965,7 @@ class PEAR_Error
      * @return string user-supplied information
      * @access public
      */
-    function getUserInfo()
+    public function getUserInfo()
     {
         return $this->userinfo;
     }
@@ -968,7 +976,7 @@ class PEAR_Error
      * @return string debug information
      * @access public
      */
-    function getDebugInfo()
+    public function getDebugInfo()
     {
         return $this->getUserInfo();
     }
@@ -977,22 +985,23 @@ class PEAR_Error
      * Get the call backtrace from where the error was generated.
      * Supported with PHP 4.3.0 or newer.
      *
-     * @param int $frame (optional) what frame to fetch
+     * @param  int   $frame (optional) what frame to fetch
      * @return array Backtrace, or NULL if not available.
      * @access public
      */
-    function getBacktrace($frame = null)
+    public function getBacktrace($frame = null)
     {
         if (defined('PEAR_IGNORE_BACKTRACE')) {
-            return null;
+            return;
         }
         if ($frame === null) {
             return $this->backtrace;
         }
+
         return $this->backtrace[$frame];
     }
 
-    function addUserInfo($info)
+    public function addUserInfo($info)
     {
         if (empty($this->userinfo)) {
             $this->userinfo = $info;
@@ -1001,7 +1010,7 @@ class PEAR_Error
         }
     }
 
-    function __toString()
+    public function __toString()
     {
         return $this->getMessage();
     }
@@ -1012,21 +1021,22 @@ class PEAR_Error
      * @return string a string with an object summary
      * @access public
      */
-    function toString()
+    public function toString()
     {
         $modes = array();
         $levels = array(E_USER_NOTICE  => 'notice',
                         E_USER_WARNING => 'warning',
-                        E_USER_ERROR   => 'error');
+                        E_USER_ERROR   => 'error', );
         if ($this->mode & PEAR_ERROR_CALLBACK) {
             if (is_array($this->callback)) {
                 $callback = (is_object($this->callback[0]) ?
                     strtolower(get_class($this->callback[0])) :
-                    $this->callback[0]) . '::' .
+                    $this->callback[0]).'::'.
                     $this->callback[1];
             } else {
                 $callback = $this->callback;
             }
+
             return sprintf('[%s: message="%s" code=%d mode=callback '.
                            'callback=%s prefix="%s" info="%s"]',
                            strtolower(get_class($this)), $this->message, $this->code,
@@ -1045,6 +1055,7 @@ class PEAR_Error
         if ($this->mode & PEAR_ERROR_RETURN) {
             $modes[] = 'return';
         }
+
         return sprintf('[%s: message="%s" code=%d mode=%s level=%s '.
                        'prefix="%s" info="%s"]',
                        strtolower(get_class($this)), $this->message, $this->code,

--- a/PEAR.php
+++ b/PEAR.php
@@ -89,64 +89,64 @@ class PEAR
     /**
      * Whether to enable internal debug messages.
      *
-     * @var bool
+     * @var     bool
      * @access  private
      */
-    public $_debug = false;
+    var $_debug = false;
 
     /**
      * Default error mode for this object.
      *
-     * @var int
+     * @var     int
      * @access  private
      */
-    public $_default_error_mode = null;
+    var $_default_error_mode = null;
 
     /**
      * Default error options used for this object when error mode
      * is PEAR_ERROR_TRIGGER.
      *
-     * @var int
+     * @var     int
      * @access  private
      */
-    public $_default_error_options = null;
+    var $_default_error_options = null;
 
     /**
      * Default error handler (callback) for this object, if error mode is
      * PEAR_ERROR_CALLBACK.
      *
-     * @var string
+     * @var     string
      * @access  private
      */
-    public $_default_error_handler = '';
+    var $_default_error_handler = '';
 
     /**
      * Which class to use for error objects.
      *
-     * @var string
+     * @var     string
      * @access  private
      */
-    public $_error_class = 'PEAR_Error';
+    var $_error_class = 'PEAR_Error';
 
     /**
      * An array of expected errors.
      *
-     * @var array
+     * @var     array
      * @access  private
      */
-    public $_expected_errors = array();
+    var $_expected_errors = array();
 
     /**
      * Constructor.  Registers this object in
      * $_PEAR_destructor_object_list for destructor emulation if a
      * destructor object exists.
      *
-     * @param  string $error_class (optional) which class to use for
-     *                             error objects, defaults to PEAR_Error.
+     * @param string $error_class  (optional) which class to use for
+     *        error objects, defaults to PEAR_Error.
      * @access public
      * @return void
      */
-    public function __construct($error_class = null)
+    function __construct($error_class = null)
     {
         $classname = strtolower(get_class($this));
         if ($this->_debug) {
@@ -184,26 +184,25 @@ class PEAR
      * @access public
      * @return void
      */
-    public function _PEAR()
-    {
+    function _PEAR() {
         if ($this->_debug) {
             printf("PEAR destructor called, class=%s\n", strtolower(get_class($this)));
         }
     }
 
     /**
-     * If you have a class that's mostly/entirely static, and you need static
-     * properties, you can use this method to simulate them. Eg. in your method(s)
-     * do this: $myVar = &PEAR::getStaticProperty('myclass', 'myVar');
-     * You MUST use a reference, or they will not persist!
-     *
-     * @access public
-     * @param  string $class The calling classname, to prevent clashes
-     * @param  string $var   The variable to retrieve.
-     * @return mixed  A reference to the variable. If not set it will be
-     *                      auto initialised to NULL.
-     */
-    public function &getStaticProperty($class, $var)
+    * If you have a class that's mostly/entirely static, and you need static
+    * properties, you can use this method to simulate them. Eg. in your method(s)
+    * do this: $myVar = &PEAR::getStaticProperty('myclass', 'myVar');
+    * You MUST use a reference, or they will not persist!
+    *
+    * @access public
+    * @param  string $class  The calling classname, to prevent clashes
+    * @param  string $var    The variable to retrieve.
+    * @return mixed   A reference to the variable. If not set it will be
+    *                 auto initialised to NULL.
+    */
+    function &getStaticProperty($class, $var)
     {
         static $properties;
         if (!isset($properties[$class])) {
@@ -218,15 +217,15 @@ class PEAR
     }
 
     /**
-     * Use this function to register a shutdown method for static
-     * classes.
-     *
-     * @access public
-     * @param  mixed $func The function name (or array of class/method) to call
-     * @param  mixed $args The arguments to pass to the function
-     * @return void
-     */
-    public function registerShutdownFunc($func, $args = array())
+    * Use this function to register a shutdown method for static
+    * classes.
+    *
+    * @access public
+    * @param  mixed $func  The function name (or array of class/method) to call
+    * @param  mixed $args  The arguments to pass to the function
+    * @return void
+    */
+    function registerShutdownFunc($func, $args = array())
     {
         // if we are called statically, there is a potential
         // that no shutdown func is registered.  Bug #6445
@@ -240,15 +239,15 @@ class PEAR
     /**
      * Tell whether a value is a PEAR error.
      *
-     * @param  mixed $data the value to test
-     * @param  int   $code if $data is an error object, return true
-     *                     only if $code is a string and
-     *                     $obj->getMessage() == $code or
-     *                     $code is an integer and $obj->getCode() == $code
+     * @param   mixed $data   the value to test
+     * @param   int   $code   if $data is an error object, return true
+     *                        only if $code is a string and
+     *                        $obj->getMessage() == $code or
+     *                        $code is an integer and $obj->getCode() == $code
      * @access  public
-     * @return bool  true if parameter is an error
+     * @return  bool    true if parameter is an error
      */
-    public function isError($data, $code = null)
+    function isError($data, $code = null)
     {
         if (!is_a($data, 'PEAR_Error')) {
             return false;
@@ -271,13 +270,13 @@ class PEAR
      * the default behaviour for that object.
      *
      * @param int $mode
-     *                  One of PEAR_ERROR_RETURN, PEAR_ERROR_PRINT,
-     *                  PEAR_ERROR_TRIGGER, PEAR_ERROR_DIE,
-     *                  PEAR_ERROR_CALLBACK or PEAR_ERROR_EXCEPTION.
+     *        One of PEAR_ERROR_RETURN, PEAR_ERROR_PRINT,
+     *        PEAR_ERROR_TRIGGER, PEAR_ERROR_DIE,
+     *        PEAR_ERROR_CALLBACK or PEAR_ERROR_EXCEPTION.
      *
      * @param mixed $options
-     *                       When $mode is PEAR_ERROR_TRIGGER, this is the error level (one
-     *                       of E_USER_NOTICE, E_USER_WARNING or E_USER_ERROR).
+     *        When $mode is PEAR_ERROR_TRIGGER, this is the error level (one
+     *        of E_USER_NOTICE, E_USER_WARNING or E_USER_ERROR).
      *
      *        When $mode is PEAR_ERROR_CALLBACK, this parameter is expected
      *        to be the callback function or method.  A callback
@@ -301,7 +300,7 @@ class PEAR
      *
      * @since PHP 4.0.5
      */
-    public function setErrorHandling($mode = null, $options = null)
+    function setErrorHandling($mode = null, $options = null)
     {
         if (isset($this) && is_a($this, 'PEAR')) {
             $setmode     = &$this->_default_error_mode;
@@ -350,17 +349,16 @@ class PEAR
      *
      * @param mixed $code a single error code or an array of error codes to expect
      *
-     * @return int the new depth of the "expected errors" stack
+     * @return int     the new depth of the "expected errors" stack
      * @access public
      */
-    public function expectError($code = '*')
+    function expectError($code = '*')
     {
         if (is_array($code)) {
             array_push($this->_expected_errors, $code);
         } else {
             array_push($this->_expected_errors, array($code));
         }
-
         return count($this->_expected_errors);
     }
 
@@ -368,9 +366,9 @@ class PEAR
      * This method pops one element off the expected error codes
      * stack.
      *
-     * @return array the list of error codes that were popped
+     * @return array   the list of error codes that were popped
      */
-    public function popExpect()
+    function popExpect()
     {
         return array_pop($this->_expected_errors);
     }
@@ -383,7 +381,7 @@ class PEAR
      * @access private
      * @since PHP 4.3.0
      */
-    public function _checkDelExpect($error_code)
+    function _checkDelExpect($error_code)
     {
         $deleted = false;
         foreach ($this->_expected_errors as $key => $error_array) {
@@ -410,7 +408,7 @@ class PEAR
      * @access public
      * @since PHP 4.3.0
      */
-    public function delExpect($error_code)
+    function delExpect($error_code)
     {
         $deleted = false;
         if ((is_array($error_code) && (0 != count($error_code)))) {
@@ -442,36 +440,36 @@ class PEAR
      *
      * @param mixed $message a text error message or a PEAR error object
      *
-     * @param int $code a numeric error code (it is up to your class
+     * @param int $code      a numeric error code (it is up to your class
      *                  to define these if you want to use codes)
      *
-     * @param int $mode One of PEAR_ERROR_RETURN, PEAR_ERROR_PRINT,
+     * @param int $mode      One of PEAR_ERROR_RETURN, PEAR_ERROR_PRINT,
      *                  PEAR_ERROR_TRIGGER, PEAR_ERROR_DIE,
      *                  PEAR_ERROR_CALLBACK, PEAR_ERROR_EXCEPTION.
      *
      * @param mixed $options If $mode is PEAR_ERROR_TRIGGER, this parameter
-     *                       specifies the PHP-internal error level (one of
-     *                       E_USER_NOTICE, E_USER_WARNING or E_USER_ERROR).
-     *                       If $mode is PEAR_ERROR_CALLBACK, this
-     *                       parameter specifies the callback function or
-     *                       method.  In other error modes this parameter
-     *                       is ignored.
+     *                  specifies the PHP-internal error level (one of
+     *                  E_USER_NOTICE, E_USER_WARNING or E_USER_ERROR).
+     *                  If $mode is PEAR_ERROR_CALLBACK, this
+     *                  parameter specifies the callback function or
+     *                  method.  In other error modes this parameter
+     *                  is ignored.
      *
      * @param string $userinfo If you need to pass along for example debug
-     *                         information, this parameter is meant for that.
+     *                  information, this parameter is meant for that.
      *
      * @param string $error_class The returned error object will be
-     *                            instantiated from this class, if specified.
+     *                  instantiated from this class, if specified.
      *
      * @param bool $skipmsg If true, raiseError will only pass error codes,
-     *                      the error message parameter will be dropped.
+     *                  the error message parameter will be dropped.
      *
      * @access public
-     * @return object a PEAR error object
+     * @return object   a PEAR error object
      * @see PEAR::setErrorHandling
      * @since PHP 4.0.5
      */
-    public function &raiseError($message = null,
+    function &raiseError($message = null,
                          $code = null,
                          $mode = null,
                          $options = null,
@@ -526,7 +524,6 @@ class PEAR
         if (intval(PHP_VERSION) < 5) {
             // little non-eval hack to fix bug #12147
             include 'PEAR/FixPHP5PEARWarnings.php';
-
             return $a;
         }
 
@@ -545,30 +542,28 @@ class PEAR
      *
      * @param mixed $message a text error message or a PEAR error object
      *
-     * @param int $code a numeric error code (it is up to your class
+     * @param int $code      a numeric error code (it is up to your class
      *                  to define these if you want to use codes)
      *
      * @param string $userinfo If you need to pass along for example debug
-     *                         information, this parameter is meant for that.
+     *                  information, this parameter is meant for that.
      *
      * @access public
-     * @return object a PEAR error object
+     * @return object   a PEAR error object
      * @see PEAR::raiseError
      */
-    public function &throwError($message = null, $code = null, $userinfo = null)
+    function &throwError($message = null, $code = null, $userinfo = null)
     {
         if (isset($this) && is_a($this, 'PEAR')) {
             $a = &$this->raiseError($message, $code, null, null, $userinfo);
-
             return $a;
         }
 
         $a = &PEAR::raiseError($message, $code, null, null, $userinfo);
-
         return $a;
     }
 
-    public function staticPushErrorHandling($mode, $options = null)
+    function staticPushErrorHandling($mode, $options = null)
     {
         $stack       = &$GLOBALS['_PEAR_error_handler_stack'];
         $def_mode    = &$GLOBALS['_PEAR_default_error_mode'];
@@ -600,11 +595,10 @@ class PEAR
                 break;
         }
         $stack[] = array($mode, $options);
-
         return true;
     }
 
-    public function staticPopErrorHandling()
+    function staticPopErrorHandling()
     {
         $stack = &$GLOBALS['_PEAR_error_handler_stack'];
         $setmode     = &$GLOBALS['_PEAR_default_error_mode'];
@@ -637,7 +631,6 @@ class PEAR
                 trigger_error("invalid error mode", E_USER_WARNING);
                 break;
         }
-
         return true;
     }
 
@@ -646,14 +639,14 @@ class PEAR
      * you can easily override the actual error handler for some code and restore
      * it later with popErrorHandling.
      *
-     * @param mixed $mode    (same as setErrorHandling)
+     * @param mixed $mode (same as setErrorHandling)
      * @param mixed $options (same as setErrorHandling)
      *
      * @return bool Always true
      *
      * @see PEAR::setErrorHandling
      */
-    public function pushErrorHandling($mode, $options = null)
+    function pushErrorHandling($mode, $options = null)
     {
         $stack = &$GLOBALS['_PEAR_error_handler_stack'];
         if (isset($this) && is_a($this, 'PEAR')) {
@@ -671,18 +664,17 @@ class PEAR
             PEAR::setErrorHandling($mode, $options);
         }
         $stack[] = array($mode, $options);
-
         return true;
     }
 
     /**
-     * Pop the last error handler used
-     *
-     * @return bool Always true
-     *
-     * @see PEAR::pushErrorHandling
-     */
-    public function popErrorHandling()
+    * Pop the last error handler used
+    *
+    * @return bool Always true
+    *
+    * @see PEAR::pushErrorHandling
+    */
+    function popErrorHandling()
     {
         $stack = &$GLOBALS['_PEAR_error_handler_stack'];
         array_pop($stack);
@@ -693,18 +685,17 @@ class PEAR
         } else {
             PEAR::setErrorHandling($mode, $options);
         }
-
         return true;
     }
 
     /**
-     * OS independent PHP extension load. Remember to take care
-     * on the correct extension name for case sensitive OSes.
-     *
-     * @param  string $ext The extension name
-     * @return bool   Success or not on the dl() call
-     */
-    public function loadExtension($ext)
+    * OS independent PHP extension load. Remember to take care
+    * on the correct extension name for case sensitive OSes.
+    *
+    * @param string $ext The extension name
+    * @return bool Success or not on the dl() call
+    */
+    function loadExtension($ext)
     {
         if (extension_loaded($ext)) {
             return true;
@@ -743,7 +734,8 @@ function _PEAR_call_destructors()
 {
     global $_PEAR_destructor_object_list;
     if (is_array($_PEAR_destructor_object_list) &&
-        sizeof($_PEAR_destructor_object_list)) {
+        sizeof($_PEAR_destructor_object_list))
+    {
         reset($_PEAR_destructor_object_list);
         if (PEAR_ZE2) {
             $destructLifoExists = PEAR5::getStaticProperty('PEAR', 'destructlifo');
@@ -803,35 +795,35 @@ function _PEAR_call_destructors()
  */
 class PEAR_Error
 {
-    public $error_message_prefix = '';
-    public $mode                 = PEAR_ERROR_RETURN;
-    public $level                = E_USER_NOTICE;
-    public $code                 = -1;
-    public $message              = '';
-    public $userinfo             = '';
-    public $backtrace            = null;
+    var $error_message_prefix = '';
+    var $mode                 = PEAR_ERROR_RETURN;
+    var $level                = E_USER_NOTICE;
+    var $code                 = -1;
+    var $message              = '';
+    var $userinfo             = '';
+    var $backtrace            = null;
 
     /**
      * PEAR_Error constructor
      *
-     * @param string $message message
+     * @param string $message  message
      *
-     * @param int $code (optional) error code
+     * @param int $code     (optional) error code
      *
-     * @param int $mode (optional) error mode, one of: PEAR_ERROR_RETURN,
-     *                  PEAR_ERROR_PRINT, PEAR_ERROR_DIE, PEAR_ERROR_TRIGGER,
-     *                  PEAR_ERROR_CALLBACK or PEAR_ERROR_EXCEPTION
+     * @param int $mode     (optional) error mode, one of: PEAR_ERROR_RETURN,
+     * PEAR_ERROR_PRINT, PEAR_ERROR_DIE, PEAR_ERROR_TRIGGER,
+     * PEAR_ERROR_CALLBACK or PEAR_ERROR_EXCEPTION
      *
-     * @param mixed $options (optional) error level, _OR_ in the case of
-     *                       PEAR_ERROR_CALLBACK, the callback function or object/method
-     *                       tuple.
+     * @param mixed $options   (optional) error level, _OR_ in the case of
+     * PEAR_ERROR_CALLBACK, the callback function or object/method
+     * tuple.
      *
      * @param string $userinfo (optional) additional user/debug info
      *
      * @access public
      *
      */
-    public function __construct($message = 'unknown error', $code = null,
+    function __construct($message = 'unknown error', $code = null,
                         $mode = null, $options = null, $userinfo = null)
     {
         if ($mode === null) {
@@ -910,7 +902,7 @@ class PEAR_Error
      * @return int error mode
      * @access public
      */
-    public function getMode()
+    function getMode()
     {
         return $this->mode;
     }
@@ -921,7 +913,7 @@ class PEAR_Error
      * @return mixed callback function or object/method array
      * @access public
      */
-    public function getCallback()
+    function getCallback()
     {
         return $this->callback;
     }
@@ -929,23 +921,23 @@ class PEAR_Error
     /**
      * Get the error message from an error object.
      *
-     * @return string full error message
+     * @return  string  full error message
      * @access public
      */
-    public function getMessage()
+    function getMessage()
     {
-        return ($this->error_message_prefix.$this->message);
+        return ($this->error_message_prefix . $this->message);
     }
 
-     /**
-      * Get error code from an error object
-      *
-      * @return int error code
-      * @access public
-      */
-     public function getCode()
+    /**
+     * Get error code from an error object
+     *
+     * @return int error code
+     * @access public
+     */
+     function getCode()
      {
-         return $this->code;
+        return $this->code;
      }
 
     /**
@@ -954,7 +946,7 @@ class PEAR_Error
      * @return string error/exception name (type)
      * @access public
      */
-    public function getType()
+    function getType()
     {
         return get_class($this);
     }
@@ -965,7 +957,7 @@ class PEAR_Error
      * @return string user-supplied information
      * @access public
      */
-    public function getUserInfo()
+    function getUserInfo()
     {
         return $this->userinfo;
     }
@@ -976,7 +968,7 @@ class PEAR_Error
      * @return string debug information
      * @access public
      */
-    public function getDebugInfo()
+    function getDebugInfo()
     {
         return $this->getUserInfo();
     }
@@ -985,23 +977,22 @@ class PEAR_Error
      * Get the call backtrace from where the error was generated.
      * Supported with PHP 4.3.0 or newer.
      *
-     * @param  int   $frame (optional) what frame to fetch
+     * @param int $frame (optional) what frame to fetch
      * @return array Backtrace, or NULL if not available.
      * @access public
      */
-    public function getBacktrace($frame = null)
+    function getBacktrace($frame = null)
     {
         if (defined('PEAR_IGNORE_BACKTRACE')) {
-            return;
+            return null;
         }
         if ($frame === null) {
             return $this->backtrace;
         }
-
         return $this->backtrace[$frame];
     }
 
-    public function addUserInfo($info)
+    function addUserInfo($info)
     {
         if (empty($this->userinfo)) {
             $this->userinfo = $info;
@@ -1010,7 +1001,7 @@ class PEAR_Error
         }
     }
 
-    public function __toString()
+    function __toString()
     {
         return $this->getMessage();
     }
@@ -1021,22 +1012,21 @@ class PEAR_Error
      * @return string a string with an object summary
      * @access public
      */
-    public function toString()
+    function toString()
     {
         $modes = array();
         $levels = array(E_USER_NOTICE  => 'notice',
                         E_USER_WARNING => 'warning',
-                        E_USER_ERROR   => 'error', );
+                        E_USER_ERROR   => 'error');
         if ($this->mode & PEAR_ERROR_CALLBACK) {
             if (is_array($this->callback)) {
                 $callback = (is_object($this->callback[0]) ?
                     strtolower(get_class($this->callback[0])) :
-                    $this->callback[0]).'::'.
+                    $this->callback[0]) . '::' .
                     $this->callback[1];
             } else {
                 $callback = $this->callback;
             }
-
             return sprintf('[%s: message="%s" code=%d mode=callback '.
                            'callback=%s prefix="%s" info="%s"]',
                            strtolower(get_class($this)), $this->message, $this->code,
@@ -1055,7 +1045,6 @@ class PEAR_Error
         if ($this->mode & PEAR_ERROR_RETURN) {
             $modes[] = 'return';
         }
-
         return sprintf('[%s: message="%s" code=%d mode=%s level=%s '.
                        'prefix="%s" info="%s"]',
                        strtolower(get_class($this)), $this->message, $this->code,

--- a/PEAR.php
+++ b/PEAR.php
@@ -146,7 +146,7 @@ class PEAR
      * @access public
      * @return void
      */
-    public function PEAR($error_class = null)
+    public function __construct($error_class = null)
     {
         $classname = strtolower(get_class($this));
         if ($this->_debug) {
@@ -831,7 +831,7 @@ class PEAR_Error
      * @access public
      *
      */
-    public function PEAR_Error($message = 'unknown error', $code = null,
+    public function __construct($message = 'unknown error', $code = null,
                         $mode = null, $options = null, $userinfo = null)
     {
         if ($mode === null) {

--- a/PEAR/Builder.php
+++ b/PEAR/Builder.php
@@ -63,7 +63,7 @@ class PEAR_Builder extends PEAR_Common
      *
      * @access public
      */
-    function PEAR_Builder(&$ui)
+    function __construct(&$ui)
     {
         parent::PEAR_Common();
         $this->setFrontendObject($ui);
@@ -230,7 +230,7 @@ class PEAR_Builder extends PEAR_Common
      *
      * @return array an array of associative arrays with built files,
      * format:
-     * array( array( 'file' => '/path/to/ext.so',
+     * array(array('file' => '/path/to/ext.so',
      *               'php_api' => YYYYMMDD,
      *               'zend_mod_api' => YYYYMMDD,
      *               'zend_ext_api' => YYYYMMDD ),

--- a/PEAR/Builder.php
+++ b/PEAR/Builder.php
@@ -65,7 +65,7 @@ class PEAR_Builder extends PEAR_Common
      */
     function __construct(&$ui)
     {
-        parent::PEAR_Common();
+        parent::__construct();
         $this->setFrontendObject($ui);
     }
 

--- a/PEAR/Builder.php
+++ b/PEAR/Builder.php
@@ -230,7 +230,7 @@ class PEAR_Builder extends PEAR_Common
      *
      * @return array an array of associative arrays with built files,
      * format:
-     * array(array('file' => '/path/to/ext.so',
+     * array( array( 'file' => '/path/to/ext.so',
      *               'php_api' => YYYYMMDD,
      *               'zend_mod_api' => YYYYMMDD,
      *               'zend_ext_api' => YYYYMMDD ),

--- a/PEAR/ChannelFile.php
+++ b/PEAR/ChannelFile.php
@@ -194,7 +194,7 @@ class PEAR_ChannelFile
      */
     var $_isValid = false;
 
-    function PEAR_ChannelFile()
+    function __construct()
     {
         $this->_stack = new PEAR_ErrorStack('PEAR_ChannelFile');
         $this->_stack->setErrorMessageTemplate($this->_getErrorMessage());

--- a/PEAR/Command/Auth.php
+++ b/PEAR/Command/Auth.php
@@ -74,7 +74,7 @@ password from your user configuration.',
      *
      * @access public
      */
-    function PEAR_Command_Auth(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Channels($ui, $config);
     }

--- a/PEAR/Command/Auth.php
+++ b/PEAR/Command/Auth.php
@@ -76,6 +76,6 @@ password from your user configuration.',
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Channels($ui, $config);
+        parent::__construct($ui, $config);
     }
 }

--- a/PEAR/Command/Build.php
+++ b/PEAR/Command/Build.php
@@ -55,7 +55,7 @@ Builds one or more extensions contained in a package.'
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Common($ui, $config);
+        parent::__construct($ui, $config);
     }
 
     function doBuild($command, $options, $params)

--- a/PEAR/Command/Build.php
+++ b/PEAR/Command/Build.php
@@ -53,7 +53,7 @@ Builds one or more extensions contained in a package.'
      *
      * @access public
      */
-    function PEAR_Command_Build(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Common($ui, $config);
     }

--- a/PEAR/Command/Channels.php
+++ b/PEAR/Command/Channels.php
@@ -169,7 +169,7 @@ configuration.',
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Common($ui, $config);
+        parent::__construct($ui, $config);
     }
 
     function _sortChannels($a, $b)

--- a/PEAR/Command/Channels.php
+++ b/PEAR/Command/Channels.php
@@ -167,7 +167,7 @@ configuration.',
      *
      * @access public
      */
-    function PEAR_Command_Channels(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Common($ui, $config);
     }

--- a/PEAR/Command/Common.php
+++ b/PEAR/Command/Common.php
@@ -81,9 +81,9 @@ class PEAR_Command_Common extends PEAR
      *
      * @access public
      */
-    function PEAR_Command_Common(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
-        parent::PEAR();
+        parent::__construct();
         $this->config = &$config;
         $this->ui = &$ui;
     }

--- a/PEAR/Command/Config.php
+++ b/PEAR/Command/Config.php
@@ -135,7 +135,7 @@ and uninstall).
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Common($ui, $config);
+        parent::__construct($ui, $config);
     }
 
     function doConfigShow($command, $options, $params)

--- a/PEAR/Command/Config.php
+++ b/PEAR/Command/Config.php
@@ -133,7 +133,7 @@ and uninstall).
      *
      * @access public
      */
-    function PEAR_Command_Config(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Common($ui, $config);
     }

--- a/PEAR/Command/Install.php
+++ b/PEAR/Command/Install.php
@@ -649,7 +649,7 @@ Run post-installation scripts in package <package>, if any exist.
         $packages = array_merge($abstractpackages, $otherpackages);
         if (!count($packages)) {
             $c = '';
-            if (isset($options['channel'])) {
+            if (isset($options['channel'])){
                 $c .= ' in channel "' . $options['channel'] . '"';
             }
             $this->ui->outputData('Nothing to ' . $command . $c);

--- a/PEAR/Command/Install.php
+++ b/PEAR/Command/Install.php
@@ -313,7 +313,7 @@ Run post-installation scripts in package <package>, if any exist.
      *
      * @access public
      */
-    function PEAR_Command_Install(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Common($ui, $config);
     }
@@ -649,7 +649,7 @@ Run post-installation scripts in package <package>, if any exist.
         $packages = array_merge($abstractpackages, $otherpackages);
         if (!count($packages)) {
             $c = '';
-            if (isset($options['channel'])){
+            if (isset($options['channel'])) {
                 $c .= ' in channel "' . $options['channel'] . '"';
             }
             $this->ui->outputData('Nothing to ' . $command . $c);

--- a/PEAR/Command/Install.php
+++ b/PEAR/Command/Install.php
@@ -315,7 +315,7 @@ Run post-installation scripts in package <package>, if any exist.
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Common($ui, $config);
+        parent::__construct($ui, $config);
     }
 
     // }}}

--- a/PEAR/Command/Mirror.php
+++ b/PEAR/Command/Mirror.php
@@ -62,7 +62,7 @@ packages within preferred_state ({config preferred_state}) will be downloaded'
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Common($ui, $config);
+        parent::__construct($ui, $config);
     }
 
     /**

--- a/PEAR/Command/Mirror.php
+++ b/PEAR/Command/Mirror.php
@@ -60,7 +60,7 @@ packages within preferred_state ({config preferred_state}) will be downloaded'
      * @param object PEAR_Frontend a reference to an frontend
      * @param object PEAR_Config a reference to the configuration data
      */
-    function PEAR_Command_Mirror(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Common($ui, $config);
     }

--- a/PEAR/Command/Package.php
+++ b/PEAR/Command/Package.php
@@ -283,7 +283,7 @@ used for automated conversion or learning the format.
      *
      * @access public
      */
-    function PEAR_Command_Package(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Common($ui, $config);
     }

--- a/PEAR/Command/Package.php
+++ b/PEAR/Command/Package.php
@@ -285,7 +285,7 @@ used for automated conversion or learning the format.
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Common($ui, $config);
+        parent::__construct($ui, $config);
     }
 
     function _displayValidationResults($err, $warn, $strict = false)

--- a/PEAR/Command/Pickle.php
+++ b/PEAR/Command/Pickle.php
@@ -78,7 +78,7 @@ generate both package.xml.
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Common($ui, $config);
+        parent::__construct($ui, $config);
     }
 
     /**

--- a/PEAR/Command/Pickle.php
+++ b/PEAR/Command/Pickle.php
@@ -76,7 +76,7 @@ generate both package.xml.
      *
      * @access public
      */
-    function PEAR_Command_Pickle(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Common($ui, $config);
     }

--- a/PEAR/Command/Registry.php
+++ b/PEAR/Command/Registry.php
@@ -100,7 +100,7 @@ installed package.'
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Common($ui, $config);
+        parent::__construct($ui, $config);
     }
 
     function _sortinfo($a, $b)

--- a/PEAR/Command/Registry.php
+++ b/PEAR/Command/Registry.php
@@ -98,7 +98,7 @@ installed package.'
      *
      * @access public
      */
-    function PEAR_Command_Registry(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Common($ui, $config);
     }

--- a/PEAR/Command/Remote.php
+++ b/PEAR/Command/Remote.php
@@ -155,7 +155,7 @@ parameter.
      *
      * @access public
      */
-    function PEAR_Command_Remote(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Common($ui, $config);
     }

--- a/PEAR/Command/Remote.php
+++ b/PEAR/Command/Remote.php
@@ -157,7 +157,7 @@ parameter.
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Common($ui, $config);
+        parent::__construct($ui, $config);
     }
 
     function _checkChannelForStatus($channel, $chan)

--- a/PEAR/Command/Test.php
+++ b/PEAR/Command/Test.php
@@ -238,7 +238,7 @@ Run regression tests with PHP\'s regression testing script (run-tests.php).',
         $run = new PEAR_RunTest($log, $options);
         $run->tests_count = $tests_count;
 
-        if (isset($options['coverage']) && extension_loaded('xdebug')) {
+        if (isset($options['coverage']) && extension_loaded('xdebug')){
             $run->xdebug_loaded = true;
         } else {
             $run->xdebug_loaded = false;

--- a/PEAR/Command/Test.php
+++ b/PEAR/Command/Test.php
@@ -100,7 +100,7 @@ Run regression tests with PHP\'s regression testing script (run-tests.php).',
      *
      * @access public
      */
-    function PEAR_Command_Test(&$ui, &$config)
+    function __construct(&$ui, &$config)
     {
         parent::PEAR_Command_Common($ui, $config);
     }
@@ -238,7 +238,7 @@ Run regression tests with PHP\'s regression testing script (run-tests.php).',
         $run = new PEAR_RunTest($log, $options);
         $run->tests_count = $tests_count;
 
-        if (isset($options['coverage']) && extension_loaded('xdebug')){
+        if (isset($options['coverage']) && extension_loaded('xdebug')) {
             $run->xdebug_loaded = true;
         } else {
             $run->xdebug_loaded = false;

--- a/PEAR/Command/Test.php
+++ b/PEAR/Command/Test.php
@@ -102,7 +102,7 @@ Run regression tests with PHP\'s regression testing script (run-tests.php).',
      */
     function __construct(&$ui, &$config)
     {
-        parent::PEAR_Command_Common($ui, $config);
+        parent::__construct($ui, $config);
     }
 
     function doRunTests($command, $options, $params)

--- a/PEAR/Common.php
+++ b/PEAR/Common.php
@@ -165,9 +165,9 @@ class PEAR_Common extends PEAR
      *
      * @access public
      */
-    function PEAR_Common()
+    function __construct()
     {
-        parent::PEAR();
+        parent::__construct();
         $this->config = &PEAR_Config::singleton();
         $this->debug = $this->config->get('verbose');
     }

--- a/PEAR/Config.php
+++ b/PEAR/Config.php
@@ -592,10 +592,10 @@ class PEAR_Config extends PEAR
      *
      * @see PEAR_Config::singleton
      */
-    function PEAR_Config($user_file = '', $system_file = '', $ftp_file = false,
+    function __construct($user_file = '', $system_file = '', $ftp_file = false,
                          $strict = true)
     {
-        $this->PEAR();
+        parent::__construct();
         PEAR_Installer_Role::initializeConfig($this);
         $sl = DIRECTORY_SEPARATOR;
         if (empty($user_file)) {

--- a/PEAR/Dependency2.php
+++ b/PEAR/Dependency2.php
@@ -220,7 +220,7 @@ class PEAR_Dependency2
                             return $this->raiseError("Cannot install %s on any Unix system");
                         }
 
-                        return $this->warning("warning: Cannot install %s on any Unix system");
+                        return $this->warning( "warning: Cannot install %s on any Unix system");
                     }
                 } else {
                     if (!in_array($this->getSysname(), $unices)) {

--- a/PEAR/Dependency2.php
+++ b/PEAR/Dependency2.php
@@ -82,7 +82,7 @@ class PEAR_Dependency2
      * @param array format of PEAR_Registry::parsedPackageName()
      * @param int installation state (one of PEAR_VALIDATE_*)
      */
-    function PEAR_Dependency2(&$config, $installoptions, $package,
+    function __construct(&$config, $installoptions, $package,
                               $state = PEAR_VALIDATE_INSTALLING)
     {
         $this->_config = &$config;
@@ -220,7 +220,7 @@ class PEAR_Dependency2
                             return $this->raiseError("Cannot install %s on any Unix system");
                         }
 
-                        return $this->warning( "warning: Cannot install %s on any Unix system");
+                        return $this->warning("warning: Cannot install %s on any Unix system");
                     }
                 } else {
                     if (!in_array($this->getSysname(), $unices)) {

--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -147,7 +147,7 @@ class PEAR_Downloader extends PEAR_Common
      */
     function __construct(&$ui, $options, &$config)
     {
-        parent::PEAR_Common();
+        parent::__construct();
         $this->_options = $options;
         $this->config = &$config;
         $this->_preferredState = $this->config->get('preferred_state');

--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -145,22 +145,26 @@ class PEAR_Downloader extends PEAR_Common
      * @param array
      * @param PEAR_Config
      */
-    function __construct(&$ui, $options, &$config)
+    function __construct($ui = null, $options = array(), $config = null)
     {
         parent::__construct();
         $this->_options = $options;
-        $this->config = &$config;
-        $this->_preferredState = $this->config->get('preferred_state');
+        if ($config !== null) {
+            $this->config = &$config;
+            $this->_preferredState = $this->config->get('preferred_state');
+        }
         $this->ui = &$ui;
         if (!$this->_preferredState) {
             // don't inadvertantly use a non-set preferred_state
             $this->_preferredState = null;
         }
 
-        if (isset($this->_options['installroot'])) {
-            $this->config->setInstallRoot($this->_options['installroot']);
+        if ($config !== null) {
+            if (isset($this->_options['installroot'])) {
+                $this->config->setInstallRoot($this->_options['installroot']);
+            }
+            $this->_registry = &$config->getRegistry();
         }
-        $this->_registry = &$config->getRegistry();
 
         if (isset($this->_options['alldeps']) || isset($this->_options['onlyreqdeps'])) {
             $this->_installed = $this->_registry->listAllPackages();

--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -145,7 +145,7 @@ class PEAR_Downloader extends PEAR_Common
      * @param array
      * @param PEAR_Config
      */
-    function PEAR_Downloader(&$ui, $options, &$config)
+    function __construct(&$ui, $options, &$config)
     {
         parent::PEAR_Common();
         $this->_options = $options;
@@ -1118,7 +1118,7 @@ class PEAR_Downloader extends PEAR_Common
                 $bytes += $params;
                 break;
             case 'start':
-                if($params[1] == -1) {
+                if ($params[1] == -1) {
                     $length = "Unknown size";
                 } else {
                     $length = number_format($params[1], 0, '', ',')." bytes";

--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -1122,7 +1122,7 @@ class PEAR_Downloader extends PEAR_Common
                 $bytes += $params;
                 break;
             case 'start':
-                if ($params[1] == -1) {
+                if($params[1] == -1) {
                     $length = "Unknown size";
                 } else {
                     $length = number_format($params[1], 0, '', ',')." bytes";

--- a/PEAR/Downloader/Package.php
+++ b/PEAR/Downloader/Package.php
@@ -130,7 +130,7 @@ class PEAR_Downloader_Package
     /**
      * @param PEAR_Downloader
      */
-    function PEAR_Downloader_Package(&$downloader)
+    function __construct(&$downloader)
     {
         $this->_downloader = &$downloader;
         $this->_config = &$this->_downloader->config;

--- a/PEAR/ErrorStack.php
+++ b/PEAR/ErrorStack.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Error Stack Implementation
- * 
+ *
  * This is an incredibly simple implementation of a very complex error handling
  * facility.  It contains the ability
  * to track multiple errors from multiple packages simultaneously.  In addition,
@@ -9,10 +9,10 @@
  * information such as the exact file, line number, class and function that
  * generated the error, and if necessary, it can raise a traditional PEAR_Error.
  * It has built-in support for PEAR::Log, to log errors as they occur
- * 
+ *
  * Since version 0.2alpha, it is also possible to selectively ignore errors,
  * through the use of an error callback, see {@link pushCallback()}
- * 
+ *
  * Since version 0.3alpha, it is possible to specify the exception class
  * returned from {@link push()}
  *
@@ -29,7 +29,7 @@
 
 /**
  * Singleton storage
- * 
+ *
  * Format:
  * <pre>
  * array(
@@ -45,7 +45,7 @@ $GLOBALS['_PEAR_ERRORSTACK_SINGLETON'] = array();
 
 /**
  * Global error callback (default)
- * 
+ *
  * This is only used if set to non-false.  * is the default callback for
  * all packages, whereas specific packages may set a default callback
  * for all instances, regardless of whether they are a singleton or not.
@@ -61,7 +61,7 @@ $GLOBALS['_PEAR_ERRORSTACK_DEFAULT_CALLBACK'] = array(
 
 /**
  * Global Log object (default)
- * 
+ *
  * This is only used if set to non-false.  Use to set a default log object for
  * all stacks, regardless of instantiation order or location
  * @see PEAR_ErrorStack::setDefaultLogger()
@@ -72,7 +72,7 @@ $GLOBALS['_PEAR_ERRORSTACK_DEFAULT_LOGGER'] = false;
 
 /**
  * Global Overriding Callback
- * 
+ *
  * This callback will override any error callbacks that specific loggers have set.
  * Use with EXTREME caution
  * @see PEAR_ErrorStack::staticPushCallback()
@@ -167,14 +167,14 @@ class PEAR_ErrorStack {
      * @access protected
      */
     var $_package;
-    
+
     /**
      * Determines whether a PEAR_Error is thrown upon every error addition
      * @var boolean
      * @access private
      */
     var $_compat = false;
-    
+
     /**
      * If set to a valid callback, this will be used to generate the error
      * message from the error code, otherwise the message passed in will be
@@ -183,7 +183,7 @@ class PEAR_ErrorStack {
      * @access private
      */
     var $_msgCallback = false;
-    
+
     /**
      * If set to a valid callback, this will be used to generate the error
      * context for an error.  For PHP-related errors, this will be a file
@@ -194,43 +194,43 @@ class PEAR_ErrorStack {
      * @access protected
      */
     var $_contextCallback = false;
-    
+
     /**
      * If set to a valid callback, this will be called every time an error
      * is pushed onto the stack.  The return value will be used to determine
      * whether to allow an error to be pushed or logged.
-     * 
+     *
      * The return value must be one an PEAR_ERRORSTACK_* constant
      * @see PEAR_ERRORSTACK_PUSHANDLOG, PEAR_ERRORSTACK_PUSH, PEAR_ERRORSTACK_LOG
      * @var false|string|array
      * @access protected
      */
     var $_errorCallback = array();
-    
+
     /**
      * PEAR::Log object for logging errors
      * @var false|Log
      * @access protected
      */
     var $_logger = false;
-    
+
     /**
      * Error messages - designed to be overridden
      * @var array
      * @abstract
      */
     var $_errorMsgs = array();
-    
+
     /**
      * Set up a new error stack
-     * 
+     *
      * @param string   $package name of the package this error stack represents
      * @param callback $msgCallback callback used for error message generation
      * @param callback $contextCallback callback used for context generation,
      *                 defaults to {@link getFileLine()}
      * @param boolean  $throwPEAR_Error
      */
-    function PEAR_ErrorStack($package, $msgCallback = false, $contextCallback = false,
+    function __construct($package, $msgCallback = false, $contextCallback = false,
                          $throwPEAR_Error = false)
     {
         $this->_package = $package;
@@ -238,10 +238,10 @@ class PEAR_ErrorStack {
         $this->setContextCallback($contextCallback);
         $this->_compat = $throwPEAR_Error;
     }
-    
+
     /**
      * Return a single error stack for this package.
-     * 
+     *
      * Note that all parameters are ignored if the stack for package $package
      * has already been instantiated
      * @param string   $package name of the package this error stack represents
@@ -276,7 +276,7 @@ class PEAR_ErrorStack {
 
     /**
      * Internal error handler for PEAR_ErrorStack class
-     * 
+     *
      * Dies if the error is an exception (and would have died anyway)
      * @access private
      */
@@ -293,10 +293,10 @@ class PEAR_ErrorStack {
             die($message);
         }
     }
-    
+
     /**
      * Set up a PEAR::Log object for all error stacks that don't have one
-     * @param Log $log 
+     * @param Log $log
      * @static
      */
     function setDefaultLogger(&$log)
@@ -307,10 +307,10 @@ class PEAR_ErrorStack {
             $GLOBALS['_PEAR_ERRORSTACK_DEFAULT_LOGGER'] = &$log;
 	}
     }
-    
+
     /**
      * Set up a PEAR::Log object for this error stack
-     * @param Log $log 
+     * @param Log $log
      */
     function setLogger(&$log)
     {
@@ -320,10 +320,10 @@ class PEAR_ErrorStack {
             $this->_logger = &$log;
         }
     }
-    
+
     /**
      * Set an error code => error message mapping callback
-     * 
+     *
      * This method sets the callback that can be used to generate error
      * messages for any instance
      * @param array|string Callback function/method
@@ -338,10 +338,10 @@ class PEAR_ErrorStack {
             }
         }
     }
-    
+
     /**
      * Get an error code => error message mapping callback
-     * 
+     *
      * This method returns the current callback that can be used to generate error
      * messages
      * @return array|string|false Callback function/method or false if none
@@ -350,10 +350,10 @@ class PEAR_ErrorStack {
     {
         return $this->_msgCallback;
     }
-    
+
     /**
      * Sets a default callback to be used by all error stacks
-     * 
+     *
      * This method sets the callback that can be used to generate error
      * messages for a singleton
      * @param array|string Callback function/method
@@ -368,10 +368,10 @@ class PEAR_ErrorStack {
         $package = $package ? $package : '*';
         $GLOBALS['_PEAR_ERRORSTACK_DEFAULT_CALLBACK'][$package] = $callback;
     }
-    
+
     /**
      * Set a callback that generates context information (location of error) for an error stack
-     * 
+     *
      * This method sets the callback that can be used to generate context
      * information for an error.  Passing in NULL will disable context generation
      * and remove the expensive call to debug_backtrace()
@@ -390,15 +390,15 @@ class PEAR_ErrorStack {
             }
         }
     }
-    
+
     /**
      * Set an error Callback
      * If set to a valid callback, this will be called every time an error
      * is pushed onto the stack.  The return value will be used to determine
      * whether to allow an error to be pushed or logged.
-     * 
+     *
      * The return value must be one of the ERRORSTACK_* constants.
-     * 
+     *
      * This functionality can be used to emulate PEAR's pushErrorHandling, and
      * the PEAR_ERROR_CALLBACK mode, without affecting the integrity of
      * the error stack or logging
@@ -410,7 +410,7 @@ class PEAR_ErrorStack {
     {
         array_push($this->_errorCallback, $cb);
     }
-    
+
     /**
      * Remove a callback from the error callback stack
      * @see pushCallback()
@@ -423,7 +423,7 @@ class PEAR_ErrorStack {
         }
         return array_pop($this->_errorCallback);
     }
-    
+
     /**
      * Set a temporary overriding error callback for every package error stack
      *
@@ -438,7 +438,7 @@ class PEAR_ErrorStack {
     {
         array_push($GLOBALS['_PEAR_ERRORSTACK_OVERRIDE_CALLBACK'], $cb);
     }
-    
+
     /**
      * Remove a temporary overriding error callback
      * @see staticPushCallback()
@@ -453,15 +453,15 @@ class PEAR_ErrorStack {
         }
         return $ret;
     }
-    
+
     /**
      * Add an error to the stack
-     * 
+     *
      * If the message generator exists, it is called with 2 parameters.
      *  - the current Error Stack object
      *  - an array that is in the same format as an error.  Available indices
      *    are 'code', 'package', 'time', 'params', 'level', and 'context'
-     * 
+     *
      * Next, if the error should contain context information, this is
      * handled by the context grabbing method.
      * Finally, the error is pushed onto the proper error stack
@@ -479,7 +479,7 @@ class PEAR_ErrorStack {
      * @return PEAR_Error|array if compatibility mode is on, a PEAR_Error is also
      * thrown.  If a PEAR_Error is returned, the userinfo
      * property is set to the following array:
-     * 
+     *
      * <code>
      * array(
      *    'code' => $code,
@@ -492,7 +492,7 @@ class PEAR_ErrorStack {
      * //['repackage' => $err] repackaged error array/Exception class
      * );
      * </code>
-     * 
+     *
      * Normally, the previous array is returned.
      */
     function push($code, $level = 'error', $params = array(), $msg = false,
@@ -506,7 +506,7 @@ class PEAR_ErrorStack {
             }
             $context = call_user_func($this->_contextCallback, $code, $params, $backtrace);
         }
-        
+
         // save error
         $time = explode(' ', microtime());
         $time = $time[1] + $time[0];
@@ -529,7 +529,7 @@ class PEAR_ErrorStack {
             $msg = call_user_func_array($this->_msgCallback,
                                         array(&$this, $err));
             $err['message'] = $msg;
-        }        
+        }
         $push = $log = true;
         $die = false;
         // try the overriding callback first
@@ -550,17 +550,17 @@ class PEAR_ErrorStack {
             }
         }
         if (is_callable($callback)) {
-            switch(call_user_func($callback, $err)){
-            	case PEAR_ERRORSTACK_IGNORE: 
+            switch(call_user_func($callback, $err)) {
+            	case PEAR_ERRORSTACK_IGNORE:
             		return $err;
         		break;
-            	case PEAR_ERRORSTACK_PUSH: 
+            	case PEAR_ERRORSTACK_PUSH:
             		$log = false;
         		break;
-            	case PEAR_ERRORSTACK_LOG: 
+            	case PEAR_ERRORSTACK_LOG:
             		$push = false;
         		break;
-            	case PEAR_ERRORSTACK_DIE: 
+            	case PEAR_ERRORSTACK_DIE:
             		$die = true;
         		break;
                 // anything else returned has the same effect as pushandlog
@@ -586,10 +586,10 @@ class PEAR_ErrorStack {
         }
         return $err;
     }
-    
+
     /**
      * Static version of {@link push()}
-     * 
+     *
      * @param string $package   Package name this error belongs to
      * @param int    $code      Package-specific error code
      * @param string $level     Error level.  This is NOT spell-checked
@@ -619,7 +619,7 @@ class PEAR_ErrorStack {
         }
         return $s->push($code, $level, $params, $msg, $repackage, $backtrace);
     }
-    
+
     /**
      * Log an error using PEAR::Log
      * @param array $err Error array
@@ -654,10 +654,10 @@ class PEAR_ErrorStack {
         }
     }
 
-    
+
     /**
      * Pop an error off of the error stack
-     * 
+     *
      * @return false|array
      * @since 0.4alpha it is no longer possible to specify a specific error
      * level to return - the last error pushed will be returned, instead
@@ -704,10 +704,10 @@ class PEAR_ErrorStack {
         }
         return count($this->_errors);
     }
-    
+
     /**
      * Retrieve all errors since last purge
-     * 
+     *
      * @param boolean set in order to empty the error stack
      * @param string level name, to return only errors of a particular severity
      * @return array
@@ -741,7 +741,7 @@ class PEAR_ErrorStack {
         $this->_errorsByLevel = array();
         return $ret;
     }
-    
+
     /**
      * Determine whether there are any errors on a single error stack, or on any error stack
      *
@@ -767,7 +767,7 @@ class PEAR_ErrorStack {
         }
         return false;
     }
-    
+
     /**
      * Get a list of all errors since last purge, organized by package
      * @since PEAR 1.4.0dev BC break! $level is now in the place $merge used to be
@@ -777,7 +777,7 @@ class PEAR_ErrorStack {
      * @param array   $sortfunc Function used to sort a merged array - default
      *        sorts by time, and should be good for most cases
      * @static
-     * @return array 
+     * @return array
      */
     function staticGetErrors($purge = false, $level = false, $merge = false,
                              $sortfunc = array('PEAR_ErrorStack', '_sortErrors'))
@@ -801,7 +801,7 @@ class PEAR_ErrorStack {
         }
         return $ret;
     }
-    
+
     /**
      * Error sorting function, sorts by time
      * @access private
@@ -856,7 +856,7 @@ class PEAR_ErrorStack {
             $ret = array('file' => $filebacktrace['file'],
                          'line' => $filebacktrace['line']);
             // rearrange for eval'd code or create function errors
-            if (strpos($filebacktrace['file'], '(') && 
+            if (strpos($filebacktrace['file'], '(') &&
             	  preg_match(';^(.*?)\((\d+)\) : (.*?)\\z;', $filebacktrace['file'],
                   $matches)) {
                 $ret['file'] = $matches[1];
@@ -878,26 +878,26 @@ class PEAR_ErrorStack {
         }
         return false;
     }
-    
+
     /**
      * Standard error message generation callback
-     * 
+     *
      * This method may also be called by a custom error message generator
      * to fill in template values from the params array, simply
      * set the third parameter to the error message template string to use
-     * 
+     *
      * The special variable %__msg% is reserved: use it only to specify
      * where a message passed in by the user should be placed in the template,
      * like so:
-     * 
+     *
      * Error message: %msg% - internal error
-     * 
+     *
      * If the message passed like so:
-     * 
+     *
      * <code>
      * $stack->push(ERROR_CODE, 'error', array(), 'server error 500');
      * </code>
-     * 
+     *
      * The returned error message will be "Error message: server error 500 -
      * internal error"
      * @param PEAR_ErrorStack
@@ -935,7 +935,7 @@ class PEAR_ErrorStack {
         }
         return $mainmsg;
     }
-    
+
     /**
      * Standard Error Message Template generator from code
      * @return string
@@ -947,15 +947,15 @@ class PEAR_ErrorStack {
         }
         return $this->_errorMsgs[$code];
     }
-    
+
     /**
      * Set the Error Message Template array
-     * 
+     *
      * The array format must be:
      * <pre>
      * array(error code => 'message template',...)
      * </pre>
-     * 
+     *
      * Error message parameters passed into {@link push()} will be used as input
      * for the error message.  If the template is 'message %foo% was %bar%', and the
      * parameters are array('foo' => 'one', 'bar' => 'six'), the error message returned will
@@ -966,11 +966,11 @@ class PEAR_ErrorStack {
     {
         $this->_errorMsgs = $template;
     }
-    
-    
+
+
     /**
      * emulate PEAR::raiseError()
-     * 
+     *
      * @return PEAR_Error
      */
     function raiseError()

--- a/PEAR/ErrorStack5.php
+++ b/PEAR/ErrorStack5.php
@@ -213,7 +213,7 @@ class PEAR_ErrorStack {
      *                 defaults to {@link getFileLine()}
      * @param boolean  $throwPEAR_Error (ignored)
      */
-    public function PEAR_ErrorStack($package, $msgCallback = false, $contextCallback = false,
+    public function __construct($package, $msgCallback = false, $contextCallback = false,
                                     $throwPEAR_Error = false)
     {
         $this->_package = $package;
@@ -540,7 +540,7 @@ class PEAR_ErrorStack {
             }
         }
         if (is_callable($callback)) {
-            switch(call_user_func($callback, $err)){
+            switch(call_user_func($callback, $err)) {
             	case PEAR_ERRORSTACK_IGNORE:
             		return $err;
         		break;

--- a/PEAR/ErrorStack5.php
+++ b/PEAR/ErrorStack5.php
@@ -540,7 +540,7 @@ class PEAR_ErrorStack {
             }
         }
         if (is_callable($callback)) {
-            switch(call_user_func($callback, $err)) {
+            switch(call_user_func($callback, $err)){
             	case PEAR_ERRORSTACK_IGNORE:
             		return $err;
         		break;

--- a/PEAR/Frontend/CLI.php
+++ b/PEAR/Frontend/CLI.php
@@ -47,9 +47,9 @@ class PEAR_Frontend_CLI extends PEAR_Frontend
         'normal' => '',
     );
 
-    function PEAR_Frontend_CLI()
+    function __construct()
     {
-        parent::PEAR();
+        parent::__construct();
         $term = getenv('TERM'); //(cox) $_ENV is empty for me in 4.1.1
         if (function_exists('posix_isatty') && !posix_isatty(1)) {
             // output is being redirected to a file or through a pipe

--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -116,7 +116,7 @@ class PEAR_Installer extends PEAR_Downloader
      *
      * @access public
      */
-    function PEAR_Installer(&$ui)
+    function __construct(&$ui)
     {
         parent::PEAR_Common();
         $this->setFrontendObject($ui);
@@ -948,7 +948,7 @@ class PEAR_Installer extends PEAR_Downloader
                         $this->_dirtree[dirname($data[1])] = true;
                         $this->pkginfo->setDirtree(dirname($data[1]));
 
-                        while(!empty($data[3]) && dirname($data[3]) != $data[3] &&
+                        while (!empty($data[3]) && dirname($data[3]) != $data[3] &&
                                 $data[3] != '/' && $data[3] != '\\') {
                             $this->pkginfo->setDirtree($pp =
                                 $this->_prependPath($data[3], $data[2]));

--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -948,7 +948,7 @@ class PEAR_Installer extends PEAR_Downloader
                         $this->_dirtree[dirname($data[1])] = true;
                         $this->pkginfo->setDirtree(dirname($data[1]));
 
-                        while (!empty($data[3]) && dirname($data[3]) != $data[3] &&
+                        while(!empty($data[3]) && dirname($data[3]) != $data[3] &&
                                 $data[3] != '/' && $data[3] != '\\') {
                             $this->pkginfo->setDirtree($pp =
                                 $this->_prependPath($data[3], $data[2]));

--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -118,7 +118,7 @@ class PEAR_Installer extends PEAR_Downloader
      */
     function __construct(&$ui)
     {
-        parent::__construct($ui);
+        parent::__construct($ui, array(), null);
         $this->setFrontendObject($ui);
         $this->debug = $this->config->get('verbose');
     }

--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -118,7 +118,7 @@ class PEAR_Installer extends PEAR_Downloader
      */
     function __construct(&$ui)
     {
-        parent::PEAR_Common();
+        parent::__construct();
         $this->setFrontendObject($ui);
         $this->debug = $this->config->get('verbose');
     }

--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -118,7 +118,7 @@ class PEAR_Installer extends PEAR_Downloader
      */
     function __construct(&$ui)
     {
-        parent::__construct();
+        parent::__construct($ui);
         $this->setFrontendObject($ui);
         $this->debug = $this->config->get('verbose');
     }

--- a/PEAR/Installer/Role/Common.php
+++ b/PEAR/Installer/Role/Common.php
@@ -39,7 +39,7 @@ class PEAR_Installer_Role_Common
     /**
      * @param PEAR_Config
      */
-    function PEAR_Installer_Role_Common(&$config)
+    function __construct(&$config)
     {
         $this->config = $config;
     }
@@ -72,7 +72,7 @@ class PEAR_Installer_Role_Common
      */
     function processInstallation($pkg, $atts, $file, $tmp_path, $layer = null)
     {
-        $roleInfo = PEAR_Installer_Role_Common::getInfo('PEAR_Installer_Role_' . 
+        $roleInfo = PEAR_Installer_Role_Common::getInfo('PEAR_Installer_Role_' .
             ucfirst(str_replace('pear_installer_role_', '', strtolower(get_class($this)))));
         if (PEAR::isError($roleInfo)) {
             return $roleInfo;
@@ -108,7 +108,7 @@ class PEAR_Installer_Role_Common
 
         // Clean up the DIRECTORY_SEPARATOR mess
         $ds2 = DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR;
-        
+
         list($dest_dir, $dest_file, $orig_file) = preg_replace(array('!\\\\+!', '!/!', "!$ds2+!"),
                                                     array(DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR,
                                                           DIRECTORY_SEPARATOR),
@@ -122,7 +122,7 @@ class PEAR_Installer_Role_Common
      */
     function getLocationConfig()
     {
-        $roleInfo = PEAR_Installer_Role_Common::getInfo('PEAR_Installer_Role_' . 
+        $roleInfo = PEAR_Installer_Role_Common::getInfo('PEAR_Installer_Role_' .
             ucfirst(str_replace('pear_installer_role_', '', strtolower(get_class($this)))));
         if (PEAR::isError($roleInfo)) {
             return $roleInfo;
@@ -143,7 +143,7 @@ class PEAR_Installer_Role_Common
 
     function isExecutable()
     {
-        $roleInfo = PEAR_Installer_Role_Common::getInfo('PEAR_Installer_Role_' . 
+        $roleInfo = PEAR_Installer_Role_Common::getInfo('PEAR_Installer_Role_' .
             ucfirst(str_replace('pear_installer_role_', '', strtolower(get_class($this)))));
         if (PEAR::isError($roleInfo)) {
             return $roleInfo;
@@ -153,7 +153,7 @@ class PEAR_Installer_Role_Common
 
     function isInstallable()
     {
-        $roleInfo = PEAR_Installer_Role_Common::getInfo('PEAR_Installer_Role_' . 
+        $roleInfo = PEAR_Installer_Role_Common::getInfo('PEAR_Installer_Role_' .
             ucfirst(str_replace('pear_installer_role_', '', strtolower(get_class($this)))));
         if (PEAR::isError($roleInfo)) {
             return $roleInfo;
@@ -163,7 +163,7 @@ class PEAR_Installer_Role_Common
 
     function isExtension()
     {
-        $roleInfo = PEAR_Installer_Role_Common::getInfo('PEAR_Installer_Role_' . 
+        $roleInfo = PEAR_Installer_Role_Common::getInfo('PEAR_Installer_Role_' .
             ucfirst(str_replace('pear_installer_role_', '', strtolower(get_class($this)))));
         if (PEAR::isError($roleInfo)) {
             return $roleInfo;

--- a/PEAR/PackageFile.php
+++ b/PEAR/PackageFile.php
@@ -67,7 +67,7 @@ class PEAR_PackageFile
      * @param   string @tmpdir Optional temporary directory for uncompressing
      *          files
      */
-    function PEAR_PackageFile(&$config, $debug = false)
+    function __construct(&$config, $debug = false)
     {
         $this->_config = $config;
         $this->_debug = $debug;

--- a/PEAR/PackageFile/Generator/v1.php
+++ b/PEAR/PackageFile/Generator/v1.php
@@ -39,7 +39,7 @@ class PEAR_PackageFile_Generator_v1
      * @var PEAR_PackageFile_v1
      */
     var $_packagefile;
-    function PEAR_PackageFile_Generator_v1(&$packagefile)
+    function __construct(&$packagefile)
     {
         $this->_packagefile = &$packagefile;
     }

--- a/PEAR/PackageFile/Generator/v2.php
+++ b/PEAR/PackageFile/Generator/v2.php
@@ -100,7 +100,7 @@ http://pear.php.net/dtd/package-2.0.xsd',
     /**
      * @param PEAR_PackageFile_v2
      */
-    function PEAR_PackageFile_Generator_v2(&$packagefile)
+    function __construct(&$packagefile)
     {
         $this->_packagefile = &$packagefile;
         if (isset($this->_packagefile->encoding)) {

--- a/PEAR/PackageFile/v1.php
+++ b/PEAR/PackageFile/v1.php
@@ -336,7 +336,7 @@ class PEAR_PackageFile_v1
      *
      * - package name
      * - channel name
-     * - dependencies 
+     * - dependencies
      * @var boolean
      * @access private
      */
@@ -346,7 +346,7 @@ class PEAR_PackageFile_v1
      * @param bool determines whether to return a PEAR_Error object, or use the PEAR_ErrorStack
      * @param string Name of Error Stack class to use.
      */
-    function PEAR_PackageFile_v1()
+    function __construct()
     {
         $this->_stack = new PEAR_ErrorStack('PEAR_PackageFile_v1');
         $this->_stack->setErrorMessageTemplate($this->_getErrorMessage());
@@ -1200,14 +1200,14 @@ class PEAR_PackageFile_v1
                         array('file' => $file));
                 }
                 if (isset($fa['install-as']) &&
-                      preg_match('~/\.\.?(/|\\z)|^\.\.?/~', 
+                      preg_match('~/\.\.?(/|\\z)|^\.\.?/~',
                                  str_replace('\\', '/', $fa['install-as']))) {
                     // install-as contains .. parent directory or . cur directory references
                     $this->_validateError(PEAR_PACKAGEFILE_ERROR_INVALID_FILENAME,
                         array('file' => $file . ' [installed as ' . $fa['install-as'] . ']'));
                 }
                 if (isset($fa['baseinstalldir']) &&
-                      preg_match('~/\.\.?(/|\\z)|^\.\.?/~', 
+                      preg_match('~/\.\.?(/|\\z)|^\.\.?/~',
                                  str_replace('\\', '/', $fa['baseinstalldir']))) {
                     // install-as contains .. parent directory or . cur directory references
                     $this->_validateError(PEAR_PACKAGEFILE_ERROR_INVALID_FILENAME,
@@ -1469,7 +1469,7 @@ class PEAR_PackageFile_v1
                     if (version_compare(zend_version(), '2.0', '<')) {
                         if (in_array(strtolower($data),
                             array('public', 'private', 'protected', 'abstract',
-                                  'interface', 'implements', 'throw') 
+                                  'interface', 'implements', 'throw')
                                  )) {
                             $this->_validateWarning(PEAR_PACKAGEFILE_ERROR_PHP5,
                                 array($file));

--- a/PEAR/PackageFile/v2.php
+++ b/PEAR/PackageFile/v2.php
@@ -129,7 +129,7 @@ class PEAR_PackageFile_v2
     /**
      * The constructor merely sets up the private error stack
      */
-    function PEAR_PackageFile_v2()
+    function __construct()
     {
         $this->_stack = new PEAR_ErrorStack('PEAR_PackageFile_v2', false, null);
         $this->_isValid = false;

--- a/PEAR/REST.php
+++ b/PEAR/REST.php
@@ -37,7 +37,7 @@ class PEAR_REST
     var $config;
     var $_options;
 
-    function PEAR_REST(&$config, $options = array())
+    function __construct(&$config, $options = array())
     {
         $this->config   = &$config;
         $this->_options = $options;

--- a/PEAR/REST/10.php
+++ b/PEAR/REST/10.php
@@ -37,7 +37,7 @@ class PEAR_REST_10
      * @var PEAR_REST
      */
     var $_rest;
-    function PEAR_REST_10($config, $options = array())
+    function __construct($config, $options = array())
     {
         $this->_rest = new PEAR_REST($config, $options);
     }

--- a/PEAR/REST/11.php
+++ b/PEAR/REST/11.php
@@ -38,7 +38,7 @@ class PEAR_REST_11
      */
     var $_rest;
 
-    function PEAR_REST_11($config, $options = array())
+    function __construct($config, $options = array())
     {
         $this->_rest = new PEAR_REST($config, $options);
     }

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -88,7 +88,7 @@ class PEAR_Registry extends PEAR
     var $pkginfo_cache = array();
 
     /** Cache of file map.  Structure:
-     * array('/path/to/file' => 'package', ... )
+     * array( '/path/to/file' => 'package', ... )
      * @var array
      */
     var $filemap_cache = array();
@@ -2186,7 +2186,7 @@ class PEAR_Registry extends PEAR
                 if ($components['scheme'] == 'http') {
                     // uri package
                     $param = array('uri' => $param, 'channel' => '__uri');
-                } elseif ($components['scheme'] != 'channel') {
+                } elseif($components['scheme'] != 'channel') {
                     return PEAR::raiseError('parsePackageName(): only channel:// uris may ' .
                         'be downloaded, not "' . $param . '"', 'invalid', null, null, $param);
                 }

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -88,7 +88,7 @@ class PEAR_Registry extends PEAR
     var $pkginfo_cache = array();
 
     /** Cache of file map.  Structure:
-     * array( '/path/to/file' => 'package', ... )
+     * array('/path/to/file' => 'package', ... )
      * @var array
      */
     var $filemap_cache = array();
@@ -131,10 +131,10 @@ class PEAR_Registry extends PEAR
      *
      * @access public
      */
-    function PEAR_Registry($pear_install_dir = PEAR_INSTALL_DIR, $pear_channel = false,
+    function __construct($pear_install_dir = PEAR_INSTALL_DIR, $pear_channel = false,
                            $pecl_channel = false)
     {
-        parent::PEAR();
+        parent::__construct();
         $this->setInstallDir($pear_install_dir);
         $this->_pearChannel = $pear_channel;
         $this->_peclChannel = $pecl_channel;
@@ -2186,7 +2186,7 @@ class PEAR_Registry extends PEAR
                 if ($components['scheme'] == 'http') {
                     // uri package
                     $param = array('uri' => $param, 'channel' => '__uri');
-                } elseif($components['scheme'] != 'channel') {
+                } elseif ($components['scheme'] != 'channel') {
                     return PEAR::raiseError('parsePackageName(): only channel:// uris may ' .
                         'be downloaded, not "' . $param . '"', 'invalid', null, null, $param);
                 }

--- a/PEAR/RunTest.php
+++ b/PEAR/RunTest.php
@@ -83,7 +83,7 @@ class PEAR_RunTest
      * An object that supports the PEAR_Common->log() signature, or null
      * @param PEAR_Common|null
      */
-    function PEAR_RunTest($logger = null, $options = array())
+    function __construct($logger = null, $options = array())
     {
         if (!defined('E_DEPRECATED')) {
             define('E_DEPRECATED', 0);
@@ -316,7 +316,7 @@ class PEAR_RunTest
             if (strpos($section_text['INI'], '{PWD}') !== false) {
                 $section_text['INI'] = str_replace('{PWD}', dirname($file), $section_text['INI']);
             }
-            $ini = preg_split( "/[\n\r]+/", $section_text['INI']);
+            $ini = preg_split("/[\n\r]+/", $section_text['INI']);
             $ini_settings = $this->settings2array($ini, $ini_settings);
         }
         $ini_settings = $this->settings2params($ini_settings);

--- a/PEAR/RunTest.php
+++ b/PEAR/RunTest.php
@@ -316,7 +316,7 @@ class PEAR_RunTest
             if (strpos($section_text['INI'], '{PWD}') !== false) {
                 $section_text['INI'] = str_replace('{PWD}', dirname($file), $section_text['INI']);
             }
-            $ini = preg_split("/[\n\r]+/", $section_text['INI']);
+            $ini = preg_split( "/[\n\r]+/", $section_text['INI']);
             $ini_settings = $this->settings2array($ini, $ini_settings);
         }
         $ini_settings = $this->settings2params($ini_settings);

--- a/PEAR/Start.php
+++ b/PEAR/Start.php
@@ -73,9 +73,9 @@ class PEAR_Start extends PEAR
     var $tarball = array();
     var $ptmp;
 
-    function PEAR_Start()
+    function __construct()
     {
-        parent::PEAR();
+        parent::__construct();
         if (OS_WINDOWS) {
             $this->configPrompt['php_bin'] = 'Path to CLI php.exe';
             $this->config[] = 'php_bin';

--- a/PEAR/Start/CLI.php
+++ b/PEAR/Start/CLI.php
@@ -22,9 +22,9 @@ class PEAR_Start_CLI extends PEAR_Start
      */
     var $php_bin_sapi;
 
-    function PEAR_Start_CLI()
+    function __construct()
     {
-        parent::PEAR_Start();
+        parent::construct();
         ini_set('html_errors', 0);
         define('WIN32GUI', OS_WINDOWS && php_sapi_name() == 'cli' && System::which('cscript'));
         $this->tty = OS_WINDOWS ? @fopen('\con', 'r') : @fopen('/dev/tty', 'r');
@@ -139,7 +139,7 @@ Please, enter the php.exe path.
                 $var = $this->config[(int)$tmp];
                 $desc = $this->configPrompt[$var];
                 $current = $this->$var;
-                if (WIN32GUI && $var != 'pear_conf'){
+                if (WIN32GUI && $var != 'pear_conf') {
                     $tmp = $this->win32BrowseForFolder("Choose a Folder for $desc [$current] :");
                     $tmp.= '\\';
                 } else {
@@ -179,7 +179,7 @@ $desc [$current] : ";
             if (file_exists($tmp . DIRECTORY_SEPARATOR . 'php.exe')) {
                 $tmp = $tmp . DIRECTORY_SEPARATOR . 'php.exe';
                 $this->php_bin_sapi = $this->win32DetectPHPSAPI();
-                if ($this->php_bin_sapi=='cgi'){
+                if ($this->php_bin_sapi=='cgi') {
                     print "
 ******************************************************************************
 NOTICE! We found php.exe under $this->php_bin, it uses a $this->php_bin_sapi SAPI.
@@ -606,7 +606,7 @@ php.ini <$pathIni> include_path updated.
                 '"PHP_PEAR_TEST_DIR"="' . addslashes($this->test_dir) . '"' . $nl;
 
         $fh = fopen($this->prefix . DIRECTORY_SEPARATOR . 'PEAR_ENV.reg', 'wb');
-        if($fh){
+        if ($fh) {
             fwrite($fh, $reg, strlen($reg));
             fclose($fh);
             echo "

--- a/PEAR/Start/CLI.php
+++ b/PEAR/Start/CLI.php
@@ -139,7 +139,7 @@ Please, enter the php.exe path.
                 $var = $this->config[(int)$tmp];
                 $desc = $this->configPrompt[$var];
                 $current = $this->$var;
-                if (WIN32GUI && $var != 'pear_conf') {
+                if (WIN32GUI && $var != 'pear_conf'){
                     $tmp = $this->win32BrowseForFolder("Choose a Folder for $desc [$current] :");
                     $tmp.= '\\';
                 } else {
@@ -179,7 +179,7 @@ $desc [$current] : ";
             if (file_exists($tmp . DIRECTORY_SEPARATOR . 'php.exe')) {
                 $tmp = $tmp . DIRECTORY_SEPARATOR . 'php.exe';
                 $this->php_bin_sapi = $this->win32DetectPHPSAPI();
-                if ($this->php_bin_sapi=='cgi') {
+                if ($this->php_bin_sapi=='cgi'){
                     print "
 ******************************************************************************
 NOTICE! We found php.exe under $this->php_bin, it uses a $this->php_bin_sapi SAPI.
@@ -606,7 +606,7 @@ php.ini <$pathIni> include_path updated.
                 '"PHP_PEAR_TEST_DIR"="' . addslashes($this->test_dir) . '"' . $nl;
 
         $fh = fopen($this->prefix . DIRECTORY_SEPARATOR . 'PEAR_ENV.reg', 'wb');
-        if ($fh) {
+        if($fh){
             fwrite($fh, $reg, strlen($reg));
             fclose($fh);
             echo "

--- a/PEAR/Task/Common.php
+++ b/PEAR/Task/Common.php
@@ -91,7 +91,7 @@ class PEAR_Task_Common
      * @param PEAR_Config
      * @param PEAR_Common
      */
-    public function PEAR_Task_Common(&$config, &$logger, $phase)
+    public function __construct(&$config, &$logger, $phase)
     {
         $this->config = &$config;
         $this->registry = &$config->getRegistry();

--- a/PEAR/Task/Common.php
+++ b/PEAR/Task/Common.php
@@ -4,14 +4,14 @@
  *
  * PHP versions 4 and 5
  *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   CVS: $Id$
- * @link      http://pear.php.net/package/PEAR
- * @since     File available since Release 1.4.0a1
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    CVS: $Id$
+ * @link       http://pear.php.net/package/PEAR
+ * @since      File available since Release 1.4.0a1
  */
 /**#@+
  * Error codes for task validation routines
@@ -42,15 +42,14 @@ define('PEAR_TASK_PACKAGEANDINSTALL', 3);
  * This will first replace any instance of @data-dir@ in the test.php file
  * with the path to the current data directory.  Then, it will include the
  * test.php file and run the script it contains to configure the package post-installation.
- *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   Release: @package_version@
- * @link      http://pear.php.net/package/PEAR
- * @since     Class available since Release 1.4.0a1
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    Release: @package_version@
+ * @link       http://pear.php.net/package/PEAR
+ * @since      Class available since Release 1.4.0a1
  * @abstract
  */
 class PEAR_Task_Common
@@ -63,35 +62,34 @@ class PEAR_Task_Common
      *   changes directly to disk
      *
      * Child task classes must override this property.
-     *
      * @access protected
      */
-    protected $type = 'simple';
+    var $type = 'simple';
     /**
      * Determines which install phase this task is executed under
      */
-    public $phase = PEAR_TASK_INSTALL;
+    var $phase = PEAR_TASK_INSTALL;
     /**
      * @access protected
      */
-    protected $config;
+    var $config;
     /**
      * @access protected
      */
-    protected $registry;
+    var $registry;
     /**
      * @access protected
      */
-    public $logger;
+    var $logger;
     /**
      * @access protected
      */
-    protected $installphase;
+    var $installphase;
     /**
      * @param PEAR_Config
      * @param PEAR_Common
      */
-    public function __construct(&$config, &$logger, $phase)
+    function __construct(&$config, &$logger, $phase)
     {
         $this->config = &$config;
         $this->registry = &$config->getRegistry();
@@ -104,67 +102,60 @@ class PEAR_Task_Common
 
     /**
      * Validate the basic contents of a task tag.
-     *
      * @param PEAR_PackageFile_v2
      * @param array
      * @param PEAR_Config
      * @param array the entire parsed <file> tag
-     *
      * @return true|array On error, return an array in format:
-     *                    array(PEAR_TASK_ERROR_???[, param1][, param2][, ...])
+     *    array(PEAR_TASK_ERROR_???[, param1][, param2][, ...])
      *
-     * For PEAR_TASK_ERROR_MISSING_ATTRIB, pass the attribute name in
-     * For PEAR_TASK_ERROR_WRONG_ATTRIB_VALUE, pass the attribute name and
-     * an array of legal values in
-     *
+     *    For PEAR_TASK_ERROR_MISSING_ATTRIB, pass the attribute name in
+     *    For PEAR_TASK_ERROR_WRONG_ATTRIB_VALUE, pass the attribute name and an array
+     *    of legal values in
      * @static
      * @abstract
      */
-    public function validateXml($pkg, $xml, $config, $fileXml)
+    function validateXml($pkg, $xml, $config, $fileXml)
     {
     }
 
     /**
      * Initialize a task instance with the parameters
-     *
-     * @param    array raw, parsed xml
-     * @param    array attributes from the <file> tag containing this task
-     * @param    string|null last installed version of this package
+     * @param array raw, parsed xml
+     * @param array attributes from the <file> tag containing this task
+     * @param string|null last installed version of this package
      * @abstract
      */
-    public function init($xml, $fileAttributes, $lastVersion)
+    function init($xml, $fileAttributes, $lastVersion)
     {
     }
 
     /**
-     * Begin a task processing session.  All multiple tasks will be processed
-     * after each file has been successfully installed, all simple tasks should
-     * perform their task here and return any errors using the custom
-     * throwError() method to allow forward compatibility
+     * Begin a task processing session.  All multiple tasks will be processed after each file
+     * has been successfully installed, all simple tasks should perform their task here and
+     * return any errors using the custom throwError() method to allow forward compatibility
      *
      * This method MUST NOT write out any changes to disk
-     *
-     * @param    PEAR_PackageFile_v2
-     * @param    string file contents
-     * @param    string the eventual final file location (informational only)
-     * @return   string|false|PEAR_Error false to skip this file, PEAR_Error to fail
-     *           (use $this->throwError), otherwise return the new contents
+     * @param PEAR_PackageFile_v2
+     * @param string file contents
+     * @param string the eventual final file location (informational only)
+     * @return string|false|PEAR_Error false to skip this file, PEAR_Error to fail
+     *         (use $this->throwError), otherwise return the new contents
      * @abstract
      */
-    public function startSession($pkg, $contents, $dest)
+    function startSession($pkg, $contents, $dest)
     {
     }
 
     /**
-     * This method is used to process each of the tasks for a particular
-     * multiple class type.  Simple tasks need not implement this method.
-     *
-     * @param    array an array of tasks
-     * @access   protected
+     * This method is used to process each of the tasks for a particular multiple class
+     * type.  Simple tasks need not implement this method.
+     * @param array an array of tasks
+     * @access protected
      * @static
      * @abstract
      */
-    public function run($tasks)
+    function run($tasks)
     {
     }
 
@@ -172,42 +163,40 @@ class PEAR_Task_Common
      * @static
      * @final
      */
-    public function hasPostinstallTasks()
+    function hasPostinstallTasks()
     {
         return isset($GLOBALS['_PEAR_TASK_POSTINSTANCES']);
     }
 
-     /**
-      * @static
-      * @final
-      */
-    public function runPostinstallTasks()
-    {
-        foreach ($GLOBALS['_PEAR_TASK_POSTINSTANCES'] as $class => $tasks) {
-            $err = call_user_func(
-                array($class, 'run'),
-                $GLOBALS['_PEAR_TASK_POSTINSTANCES'][$class]
-            );
-            if ($err) {
-                return PEAR_Task_Common::throwError($err);
-            }
-        }
-        unset($GLOBALS['_PEAR_TASK_POSTINSTANCES']);
+    /**
+     * @static
+     * @final
+     */
+     function runPostinstallTasks()
+     {
+         foreach ($GLOBALS['_PEAR_TASK_POSTINSTANCES'] as $class => $tasks) {
+             $err = call_user_func(array($class, 'run'),
+                  $GLOBALS['_PEAR_TASK_POSTINSTANCES'][$class]);
+             if ($err) {
+                 return PEAR_Task_Common::throwError($err);
+             }
+         }
+         unset($GLOBALS['_PEAR_TASK_POSTINSTANCES']);
     }
 
     /**
      * Determines whether a role is a script
      * @return bool
      */
-    public function isScript()
+    function isScript()
     {
-            return $this->type == 'script';
+        return $this->type == 'script';
     }
 
-    public function throwError($msg, $code = -1)
+    function throwError($msg, $code = -1)
     {
         include_once 'PEAR.php';
-
         return PEAR::raiseError($msg, $code);
     }
 }
+?>

--- a/PEAR/Task/Postinstallscript.php
+++ b/PEAR/Task/Postinstallscript.php
@@ -4,14 +4,14 @@
  *
  * PHP versions 4 and 5
  *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   CVS: $Id$
- * @link      http://pear.php.net/package/PEAR
- * @since     File available since Release 1.4.0a1
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    CVS: $Id$
+ * @link       http://pear.php.net/package/PEAR
+ * @since      File available since Release 1.4.0a1
  */
 /**
  * Base class
@@ -22,96 +22,85 @@ require_once 'PEAR/Task/Common.php';
  *
  * Note that post-install scripts are handled separately from installation, by the
  * "pear run-scripts" command
- *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   Release: @package_version@
- * @link      http://pear.php.net/package/PEAR
- * @since     Class available since Release 1.4.0a1
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    Release: @package_version@
+ * @link       http://pear.php.net/package/PEAR
+ * @since      Class available since Release 1.4.0a1
  */
 class PEAR_Task_Postinstallscript extends PEAR_Task_Common
 {
-    public $type = 'script';
-    public $_class;
-    public $_params;
-    public $_obj;
+    var $type = 'script';
+    var $_class;
+    var $_params;
+    var $_obj;
     /**
      *
      * @var PEAR_PackageFile_v2
      */
-    public $_pkg;
-    public $_contents;
-    public $phase = PEAR_TASK_INSTALL;
+    var $_pkg;
+    var $_contents;
+    var $phase = PEAR_TASK_INSTALL;
 
     /**
      * Validate the raw xml at parsing-time.
      *
      * This also attempts to validate the script to make sure it meets the criteria
      * for a post-install script
-     *
-     * @param  PEAR_PackageFile_v2
-     * @param  array The XML contents of the <postinstallscript> tag
-     * @param  PEAR_Config
-     * @param  array the entire parsed <file> tag
+     * @param PEAR_PackageFile_v2
+     * @param array The XML contents of the <postinstallscript> tag
+     * @param PEAR_Config
+     * @param array the entire parsed <file> tag
      * @static
      */
-    public function validateXml($pkg, $xml, $config, $fileXml)
+    function validateXml($pkg, $xml, $config, $fileXml)
     {
         if ($fileXml['role'] != 'php') {
-            return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-            $fileXml['name'].'" must be role="php"', );
+            return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+            $fileXml['name'] . '" must be role="php"');
         }
         PEAR::pushErrorHandling(PEAR_ERROR_RETURN);
         $file = $pkg->getFileContents($fileXml['name']);
         if (PEAR::isError($file)) {
             PEAR::popErrorHandling();
-
-            return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                $fileXml['name'].'" is not valid: '.
-                $file->getMessage(), );
+            return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                $fileXml['name'] . '" is not valid: ' .
+                $file->getMessage());
         } elseif ($file === null) {
-            return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                $fileXml['name'].'" could not be retrieved for processing!', );
+            return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                $fileXml['name'] . '" could not be retrieved for processing!');
         } else {
             $analysis = $pkg->analyzeSourceCode($file, true);
             if (!$analysis) {
                 PEAR::popErrorHandling();
                 $warnings = '';
                 foreach ($pkg->getValidationWarnings() as $warn) {
-                    $warnings .= $warn['message']."\n";
+                    $warnings .= $warn['message'] . "\n";
                 }
-
-                return array(PEAR_TASK_ERROR_INVALID, 'Analysis of post-install script "'.
-                    $fileXml['name'].'" failed: '.$warnings, );
+                return array(PEAR_TASK_ERROR_INVALID, 'Analysis of post-install script "' .
+                    $fileXml['name'] . '" failed: ' . $warnings);
             }
             if (count($analysis['declared_classes']) != 1) {
                 PEAR::popErrorHandling();
-
-                return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                    $fileXml['name'].'" must declare exactly 1 class', );
+                return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                    $fileXml['name'] . '" must declare exactly 1 class');
             }
             $class = $analysis['declared_classes'][0];
-            if ($class != str_replace(
-                array('/', '.php'), array('_', ''),
-                $fileXml['name']
-            ).'_postinstall') {
+            if ($class != str_replace(array('/', '.php'), array('_', ''),
+                  $fileXml['name']) . '_postinstall') {
                 PEAR::popErrorHandling();
-
-                return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                    $fileXml['name'].'" class "'.$class.'" must be named "'.
-                    str_replace(
-                        array('/', '.php'), array('_', ''),
-                        $fileXml['name']
-                    ).'_postinstall"', );
+                return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                    $fileXml['name'] . '" class "' . $class . '" must be named "' .
+                    str_replace(array('/', '.php'), array('_', ''),
+                    $fileXml['name']) . '_postinstall"');
             }
             if (!isset($analysis['declared_methods'][$class])) {
                 PEAR::popErrorHandling();
-
-                return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                    $fileXml['name'].'" must declare methods init() and run()', );
+                return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                    $fileXml['name'] . '" must declare methods init() and run()');
             }
             $methods = array('init' => 0, 'run' => 1);
             foreach ($analysis['declared_methods'][$class] as $method) {
@@ -121,137 +110,129 @@ class PEAR_Task_Postinstallscript extends PEAR_Task_Common
             }
             if (count($methods)) {
                 PEAR::popErrorHandling();
-
-                return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                    $fileXml['name'].'" must declare methods init() and run()', );
+                return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                    $fileXml['name'] . '" must declare methods init() and run()');
             }
         }
         PEAR::popErrorHandling();
         $definedparams = array();
-        $tasksNamespace = $pkg->getTasksNs().':';
-        if (!isset($xml[$tasksNamespace.'paramgroup']) && isset($xml['paramgroup'])) {
+        $tasksNamespace = $pkg->getTasksNs() . ':';
+        if (!isset($xml[$tasksNamespace . 'paramgroup']) && isset($xml['paramgroup'])) {
             // in order to support the older betas, which did not expect internal tags
             // to also use the namespace
             $tasksNamespace = '';
         }
-        if (isset($xml[$tasksNamespace.'paramgroup'])) {
-            $params = $xml[$tasksNamespace.'paramgroup'];
+        if (isset($xml[$tasksNamespace . 'paramgroup'])) {
+            $params = $xml[$tasksNamespace . 'paramgroup'];
             if (!is_array($params) || !isset($params[0])) {
                 $params = array($params);
             }
             foreach ($params as $param) {
-                if (!isset($param[$tasksNamespace.'id'])) {
-                    return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                        $fileXml['name'].'" <paramgroup> must have '.
-                        'an '.$tasksNamespace.'id> tag', );
+                if (!isset($param[$tasksNamespace . 'id'])) {
+                    return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                        $fileXml['name'] . '" <paramgroup> must have ' .
+                        'an ' . $tasksNamespace . 'id> tag');
                 }
-                if (isset($param[$tasksNamespace.'name'])) {
-                    if (!in_array($param[$tasksNamespace.'name'], $definedparams)) {
-                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                            $fileXml['name'].'" '.$tasksNamespace.
-                            'paramgroup> id "'.$param[$tasksNamespace.'id'].
-                            '" parameter "'.$param[$tasksNamespace.'name'].
-                            '" has not been previously defined', );
+                if (isset($param[$tasksNamespace . 'name'])) {
+                    if (!in_array($param[$tasksNamespace . 'name'], $definedparams)) {
+                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                            $fileXml['name'] . '" ' . $tasksNamespace .
+                            'paramgroup> id "' . $param[$tasksNamespace . 'id'] .
+                            '" parameter "' . $param[$tasksNamespace . 'name'] .
+                            '" has not been previously defined');
                     }
-                    if (!isset($param[$tasksNamespace.'conditiontype'])) {
-                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                            $fileXml['name'].'" '.$tasksNamespace.
-                            'paramgroup> id "'.$param[$tasksNamespace.'id'].
-                            '" must have a '.$tasksNamespace.
-                            'conditiontype> tag containing either "=", '.
-                            '"!=", or "preg_match"', );
+                    if (!isset($param[$tasksNamespace . 'conditiontype'])) {
+                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                            $fileXml['name'] . '" ' . $tasksNamespace .
+                            'paramgroup> id "' . $param[$tasksNamespace . 'id'] .
+                            '" must have a ' . $tasksNamespace .
+                            'conditiontype> tag containing either "=", ' .
+                            '"!=", or "preg_match"');
                     }
-                    if (!in_array(
-                        $param[$tasksNamespace.'conditiontype'],
-                        array('=', '!=', 'preg_match')
-                    )) {
-                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                            $fileXml['name'].'" '.$tasksNamespace.
-                            'paramgroup> id "'.$param[$tasksNamespace.'id'].
-                            '" must have a '.$tasksNamespace.
-                            'conditiontype> tag containing either "=", '.
-                            '"!=", or "preg_match"', );
+                    if (!in_array($param[$tasksNamespace . 'conditiontype'],
+                          array('=', '!=', 'preg_match'))) {
+                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                            $fileXml['name'] . '" ' . $tasksNamespace .
+                            'paramgroup> id "' . $param[$tasksNamespace . 'id'] .
+                            '" must have a ' . $tasksNamespace .
+                            'conditiontype> tag containing either "=", ' .
+                            '"!=", or "preg_match"');
                     }
-                    if (!isset($param[$tasksNamespace.'value'])) {
-                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                            $fileXml['name'].'" '.$tasksNamespace.
-                            'paramgroup> id "'.$param[$tasksNamespace.'id'].
-                            '" must have a '.$tasksNamespace.
-                            'value> tag containing expected parameter value', );
+                    if (!isset($param[$tasksNamespace . 'value'])) {
+                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                            $fileXml['name'] . '" ' . $tasksNamespace .
+                            'paramgroup> id "' . $param[$tasksNamespace . 'id'] .
+                            '" must have a ' . $tasksNamespace .
+                            'value> tag containing expected parameter value');
                     }
                 }
-                if (isset($param[$tasksNamespace.'instructions'])) {
-                    if (!is_string($param[$tasksNamespace.'instructions'])) {
-                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                            $fileXml['name'].'" '.$tasksNamespace.
-                            'paramgroup> id "'.$param[$tasksNamespace.'id'].
-                            '" '.$tasksNamespace.'instructions> must be simple text', );
+                if (isset($param[$tasksNamespace . 'instructions'])) {
+                    if (!is_string($param[$tasksNamespace . 'instructions'])) {
+                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                            $fileXml['name'] . '" ' . $tasksNamespace .
+                            'paramgroup> id "' . $param[$tasksNamespace . 'id'] .
+                            '" ' . $tasksNamespace . 'instructions> must be simple text');
                     }
                 }
-                if (!isset($param[$tasksNamespace.'param'])) {
+                if (!isset($param[$tasksNamespace . 'param'])) {
                     continue; // <param> is no longer required
                 }
-                $subparams = $param[$tasksNamespace.'param'];
+                $subparams = $param[$tasksNamespace . 'param'];
                 if (!is_array($subparams) || !isset($subparams[0])) {
                     $subparams = array($subparams);
                 }
                 foreach ($subparams as $subparam) {
-                    if (!isset($subparam[$tasksNamespace.'name'])) {
-                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                            $fileXml['name'].'" parameter for '.
-                            $tasksNamespace.'paramgroup> id "'.
-                            $param[$tasksNamespace.'id'].'" must have '.
-                            'a '.$tasksNamespace.'name> tag', );
+                    if (!isset($subparam[$tasksNamespace . 'name'])) {
+                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                            $fileXml['name'] . '" parameter for ' .
+                            $tasksNamespace . 'paramgroup> id "' .
+                            $param[$tasksNamespace . 'id'] . '" must have ' .
+                            'a ' . $tasksNamespace . 'name> tag');
                     }
-                    if (!preg_match(
-                        '/[a-zA-Z0-9]+/',
-                        $subparam[$tasksNamespace.'name']
-                    )) {
-                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                            $fileXml['name'].'" parameter "'.
-                            $subparam[$tasksNamespace.'name'].
-                            '" for '.$tasksNamespace.'paramgroup> id "'.
-                            $param[$tasksNamespace.'id'].
-                            '" is not a valid name.  Must contain only alphanumeric characters', );
+                    if (!preg_match('/[a-zA-Z0-9]+/',
+                          $subparam[$tasksNamespace . 'name'])) {
+                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                            $fileXml['name'] . '" parameter "' .
+                            $subparam[$tasksNamespace . 'name'] .
+                            '" for ' . $tasksNamespace . 'paramgroup> id "' .
+                            $param[$tasksNamespace . 'id'] .
+                            '" is not a valid name.  Must contain only alphanumeric characters');
                     }
-                    if (!isset($subparam[$tasksNamespace.'prompt'])) {
-                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                            $fileXml['name'].'" parameter "'.
-                            $subparam[$tasksNamespace.'name'].
-                            '" for '.$tasksNamespace.'paramgroup> id "'.
-                            $param[$tasksNamespace.'id'].
-                            '" must have a '.$tasksNamespace.'prompt> tag', );
+                    if (!isset($subparam[$tasksNamespace . 'prompt'])) {
+                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                            $fileXml['name'] . '" parameter "' .
+                            $subparam[$tasksNamespace . 'name'] .
+                            '" for ' . $tasksNamespace . 'paramgroup> id "' .
+                            $param[$tasksNamespace . 'id'] .
+                            '" must have a ' . $tasksNamespace . 'prompt> tag');
                     }
-                    if (!isset($subparam[$tasksNamespace.'type'])) {
-                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "'.
-                            $fileXml['name'].'" parameter "'.
-                            $subparam[$tasksNamespace.'name'].
-                            '" for '.$tasksNamespace.'paramgroup> id "'.
-                            $param[$tasksNamespace.'id'].
-                            '" must have a '.$tasksNamespace.'type> tag', );
+                    if (!isset($subparam[$tasksNamespace . 'type'])) {
+                        return array(PEAR_TASK_ERROR_INVALID, 'Post-install script "' .
+                            $fileXml['name'] . '" parameter "' .
+                            $subparam[$tasksNamespace . 'name'] .
+                            '" for ' . $tasksNamespace . 'paramgroup> id "' .
+                            $param[$tasksNamespace . 'id'] .
+                            '" must have a ' . $tasksNamespace . 'type> tag');
                     }
-                    $definedparams[] = $param[$tasksNamespace.'id'].'::'.
-                    $subparam[$tasksNamespace.'name'];
+                    $definedparams[] = $param[$tasksNamespace . 'id'] . '::' .
+                    $subparam[$tasksNamespace . 'name'];
                 }
             }
         }
-
         return true;
     }
 
     /**
      * Initialize a task instance with the parameters
-     * @param array       $xml         raw, parsed xml
-     * @param array       $fileattribs attributes from the <file> tag containing
-     *                                 this task
-     * @param string|null $lastversion last installed version of this package,
-     *                                 if any (useful for upgrades)
+     * @param array raw, parsed xml
+     * @param array attributes from the <file> tag containing this task
+     * @param string|null last installed version of this package, if any (useful for upgrades)
      */
-    public function init($xml, $fileattribs, $lastversion)
+    function init($xml, $fileattribs, $lastversion)
     {
         $this->_class = str_replace('/', '_', $fileattribs['name']);
         $this->_filename = $fileattribs['name'];
-        $this->_class = str_replace('.php', '', $this->_class).'_postinstall';
+        $this->_class = str_replace ('.php', '', $this->_class) . '_postinstall';
         $this->_params = $xml;
         $this->_lastversion = $lastversion;
     }
@@ -261,7 +242,7 @@ class PEAR_Task_Postinstallscript extends PEAR_Task_Common
      *
      * @access private
      */
-    public function _stripNamespace($params = null)
+    function _stripNamespace($params = null)
     {
         if ($params === null) {
             $params = array();
@@ -272,7 +253,7 @@ class PEAR_Task_Postinstallscript extends PEAR_Task_Common
                 if (is_array($param)) {
                     $param = $this->_stripNamespace($param);
                 }
-                $params[str_replace($this->_pkg->getTasksNs().':', '', $i)] = $param;
+                $params[str_replace($this->_pkg->getTasksNs() . ':', '', $i)] = $param;
             }
             $this->_params = $params;
         } else {
@@ -281,24 +262,21 @@ class PEAR_Task_Postinstallscript extends PEAR_Task_Common
                 if (is_array($param)) {
                     $param = $this->_stripNamespace($param);
                 }
-                $newparams[str_replace($this->_pkg->getTasksNs().':', '', $i)] = $param;
+                $newparams[str_replace($this->_pkg->getTasksNs() . ':', '', $i)] = $param;
             }
-
             return $newparams;
         }
     }
 
     /**
-     * Unlike other tasks, the installed file name is passed in instead of the
-     * file contents, because this task is handled post-installation
-     *
-     * @param mixed  $pkg      PEAR_PackageFile_v1|PEAR_PackageFile_v2
-     * @param string $contents file name
-     *
+     * Unlike other tasks, the installed file name is passed in instead of the file contents,
+     * because this task is handled post-installation
+     * @param PEAR_PackageFile_v1|PEAR_PackageFile_v2
+     * @param string file name
      * @return bool|PEAR_Error false to skip this file, PEAR_Error to fail
-     *                         (use $this->throwError)
+     *         (use $this->throwError)
      */
-    public function startSession($pkg, $contents)
+    function startSession($pkg, $contents)
     {
         if ($this->installphase != PEAR_TASK_INSTALL) {
             return false;
@@ -306,47 +284,40 @@ class PEAR_Task_Postinstallscript extends PEAR_Task_Common
         // remove the tasks: namespace if present
         $this->_pkg = $pkg;
         $this->_stripNamespace();
-        $this->logger->log(
-            0, 'Including external post-installation script "'.
-            $contents.'" - any errors are in this script'
-        );
+        $this->logger->log(0, 'Including external post-installation script "' .
+            $contents . '" - any errors are in this script');
         include_once $contents;
         if (class_exists($this->_class)) {
             $this->logger->log(0, 'Inclusion succeeded');
         } else {
-            return $this->throwError(
-                'init of post-install script class "'.$this->_class
-                .'" failed'
-            );
+            return $this->throwError('init of post-install script class "' . $this->_class
+                . '" failed');
         }
-        $this->_obj = new $this->_class();
-        $this->logger->log(1, 'running post-install script "'.$this->_class.'->init()"');
+        $this->_obj = new $this->_class;
+        $this->logger->log(1, 'running post-install script "' . $this->_class . '->init()"');
         PEAR::pushErrorHandling(PEAR_ERROR_RETURN);
         $res = $this->_obj->init($this->config, $pkg, $this->_lastversion);
         PEAR::popErrorHandling();
         if ($res) {
             $this->logger->log(0, 'init succeeded');
         } else {
-            return $this->throwError(
-                'init of post-install script "'.$this->_class.
-                '->init()" failed'
-            );
+            return $this->throwError('init of post-install script "' . $this->_class .
+                '->init()" failed');
         }
         $this->_contents = $contents;
-
         return true;
     }
 
     /**
      * No longer used
-     *
-     * @see    PEAR_PackageFile_v2::runPostinstallScripts()
-     * @param  array an array of tasks
-     * @param  string install or upgrade
+     * @see PEAR_PackageFile_v2::runPostinstallScripts()
+     * @param array an array of tasks
+     * @param string install or upgrade
      * @access protected
      * @static
      */
-    public function run()
+    function run()
     {
     }
 }
+?>

--- a/PEAR/Task/Postinstallscript/rw.php
+++ b/PEAR/Task/Postinstallscript/rw.php
@@ -4,14 +4,14 @@
  *
  * PHP versions 4 and 5
  *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   CVS: $Id$
- * @link      http://pear.php.net/package/PEAR
- * @since     File available since Release 1.4.0a10
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    CVS: $Id$
+ * @link       http://pear.php.net/package/PEAR
+ * @since      File available since Release 1.4.0a10
  */
 /**
  * Base class
@@ -35,18 +35,17 @@ class PEAR_Task_Postinstallscript_rw extends PEAR_Task_Postinstallscript
      *
      * @var PEAR_PackageFile_v2_rw
      */
-    public $_pkg;
+    var $_pkg;
     /**
      * Enter description here...
      *
-     * @param PEAR_PackageFile_v2_rw $pkg     Package
-     * @param PEAR_Config            $config  Config
-     * @param PEAR_Frontend          $logger  Logger
-     * @param array                  $fileXml XML
-     *
+     * @param PEAR_PackageFile_v2_rw $pkg
+     * @param PEAR_Config $config
+     * @param PEAR_Frontend $logger
+     * @param array $fileXml
      * @return PEAR_Task_Postinstallscript_rw
      */
-    public function __construct(&$pkg, &$config, &$logger, $fileXml)
+    function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
         parent::__construct($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;
@@ -54,12 +53,12 @@ class PEAR_Task_Postinstallscript_rw extends PEAR_Task_Postinstallscript
         $this->_params = array();
     }
 
-    public function validate()
+    function validate()
     {
         return $this->validateXml($this->_pkg, $this->_params, $this->config, $this->_contents);
     }
 
-    public function getName()
+    function getName()
     {
         return 'postinstallscript';
     }
@@ -74,31 +73,30 @@ class PEAR_Task_Postinstallscript_rw extends PEAR_Task_Postinstallscript
      *
      * Use {@link addConditionTypeGroup()} to add a <paramgroup> containing
      * a <conditiontype> tag
-     *
-     * @param string       $id           <paramgroup> id as seen by the script
-     * @param array|false  $params       array of getParam() calls, or false for no params
+     * @param string $id <paramgroup> id as seen by the script
+     * @param array|false $params array of getParam() calls, or false for no params
      * @param string|false $instructions
      */
-    public function addParamGroup($id, $params = false, $instructions = false)
+    function addParamGroup($id, $params = false, $instructions = false)
     {
         if ($params && isset($params[0]) && !isset($params[1])) {
             $params = $params[0];
         }
         $stuff =
             array(
-                $this->_pkg->getTasksNs().':id' => $id,
+                $this->_pkg->getTasksNs() . ':id' => $id,
             );
         if ($instructions) {
-            $stuff[$this->_pkg->getTasksNs().':instructions'] = $instructions;
+            $stuff[$this->_pkg->getTasksNs() . ':instructions'] = $instructions;
         }
         if ($params) {
-            $stuff[$this->_pkg->getTasksNs().':param'] = $params;
+            $stuff[$this->_pkg->getTasksNs() . ':param'] = $params;
         }
-        $this->_params[$this->_pkg->getTasksNs().':paramgroup'][] = $stuff;
+        $this->_params[$this->_pkg->getTasksNs() . ':paramgroup'][] = $stuff;
     }
 
     /**
-     * Add a complex <paramgroup> to the post-install script with conditions
+     * add a complex <paramgroup> to the post-install script with conditions
      *
      * This inserts a <paramgroup> with
      *
@@ -109,75 +107,63 @@ class PEAR_Task_Postinstallscript_rw extends PEAR_Task_Postinstallscript
      *
      * Use {@link addParamGroup()} to add a simple <paramgroup>
      *
-     * @param string       $id            <paramgroup> id as seen by the script
-     * @param string       $oldgroup      <paramgroup> id of the section referenced by
-     *                                    <conditiontype>
-     * @param string       $param         name of the <param> from the older section referenced
-     *                                    by <contitiontype>
-     * @param string       $value         value to match of the parameter
-     * @param string       $conditiontype one of '=', '!=', 'preg_match'
-     * @param array|false  $params        array of getParam() calls, or false for no params
+     * @param string $id <paramgroup> id as seen by the script
+     * @param string $oldgroup <paramgroup> id of the section referenced by
+     *                         <conditiontype>
+     * @param string $param name of the <param> from the older section referenced
+     *                      by <contitiontype>
+     * @param string $value value to match of the parameter
+     * @param string $conditiontype one of '=', '!=', 'preg_match'
+     * @param array|false $params array of getParam() calls, or false for no params
      * @param string|false $instructions
      */
-    public function addConditionTypeGroup($id,
-        $oldgroup,
-        $param,
-        $value,
-        $conditiontype = '=',
-        $params = false,
-        $instructions = false
-    ) {
+    function addConditionTypeGroup($id, $oldgroup, $param, $value, $conditiontype = '=',
+                                   $params = false, $instructions = false)
+    {
         if ($params && isset($params[0]) && !isset($params[1])) {
             $params = $params[0];
         }
         $stuff = array(
-            $this->_pkg->getTasksNs().':id' => $id,
+            $this->_pkg->getTasksNs() . ':id' => $id,
         );
         if ($instructions) {
-            $stuff[$this->_pkg->getTasksNs().':instructions'] = $instructions;
+            $stuff[$this->_pkg->getTasksNs() . ':instructions'] = $instructions;
         }
-        $stuff[$this->_pkg->getTasksNs().':name'] = $oldgroup.'::'.$param;
-        $stuff[$this->_pkg->getTasksNs().':conditiontype'] = $conditiontype;
-        $stuff[$this->_pkg->getTasksNs().':value'] = $value;
+        $stuff[$this->_pkg->getTasksNs() . ':name'] = $oldgroup . '::' . $param;
+        $stuff[$this->_pkg->getTasksNs() . ':conditiontype'] = $conditiontype;
+        $stuff[$this->_pkg->getTasksNs() . ':value'] = $value;
         if ($params) {
-            $stuff[$this->_pkg->getTasksNs().':param'] = $params;
+            $stuff[$this->_pkg->getTasksNs() . ':param'] = $params;
         }
-        $this->_params[$this->_pkg->getTasksNs().':paramgroup'][] = $stuff;
+        $this->_params[$this->_pkg->getTasksNs() . ':paramgroup'][] = $stuff;
     }
 
-    public function getXml()
+    function getXml()
     {
         return $this->_params;
     }
 
     /**
      * Use to set up a param tag for use in creating a paramgroup
-     *
-     * @param mixed  $name    Name of parameter
-     * @param mixed  $prompt  Prompt
-     * @param string $type    Type, defaults to 'string'
-     * @param mixed  $default Default value
-     *
      * @static
-     * @return array
      */
-    public function getParam($name, $prompt, $type = 'string', $default = null)
+    function getParam($name, $prompt, $type = 'string', $default = null)
     {
         if ($default !== null) {
             return
             array(
-                $this->_pkg->getTasksNs().':name' => $name,
-                $this->_pkg->getTasksNs().':prompt' => $prompt,
-                $this->_pkg->getTasksNs().':type' => $type,
-                $this->_pkg->getTasksNs().':default' => $default,
+                $this->_pkg->getTasksNs() . ':name' => $name,
+                $this->_pkg->getTasksNs() . ':prompt' => $prompt,
+                $this->_pkg->getTasksNs() . ':type' => $type,
+                $this->_pkg->getTasksNs() . ':default' => $default
             );
         }
-
         return
             array(
-                $this->_pkg->getTasksNs().':name' => $name,
-                $this->_pkg->getTasksNs().':prompt' => $prompt,
-                $this->_pkg->getTasksNs().':type' => $type,
+                $this->_pkg->getTasksNs() . ':name' => $name,
+                $this->_pkg->getTasksNs() . ':prompt' => $prompt,
+                $this->_pkg->getTasksNs() . ':type' => $type,
             );
     }
 }
+?>

--- a/PEAR/Task/Postinstallscript/rw.php
+++ b/PEAR/Task/Postinstallscript/rw.php
@@ -46,7 +46,7 @@ class PEAR_Task_Postinstallscript_rw extends PEAR_Task_Postinstallscript
      *
      * @return PEAR_Task_Postinstallscript_rw
      */
-    public function PEAR_Task_Postinstallscript_rw(&$pkg, &$config, &$logger, $fileXml)
+    public function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
         parent::PEAR_Task_Common($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;

--- a/PEAR/Task/Postinstallscript/rw.php
+++ b/PEAR/Task/Postinstallscript/rw.php
@@ -48,7 +48,7 @@ class PEAR_Task_Postinstallscript_rw extends PEAR_Task_Postinstallscript
      */
     public function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
-        parent::PEAR_Task_Common($config, $logger, PEAR_TASK_PACKAGE);
+        parent::__construct($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;
         $this->_pkg = &$pkg;
         $this->_params = array();

--- a/PEAR/Task/Replace.php
+++ b/PEAR/Task/Replace.php
@@ -4,14 +4,14 @@
  *
  * PHP versions 4 and 5
  *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   CVS: $Id$
- * @link      http://pear.php.net/package/PEAR
- * @since     File available since Release 1.4.0a1
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    CVS: $Id$
+ * @link       http://pear.php.net/package/PEAR
+ * @since      File available since Release 1.4.0a1
  */
 /**
  * Base class
@@ -30,19 +30,18 @@ require_once 'PEAR/Task/Common.php';
  */
 class PEAR_Task_Replace extends PEAR_Task_Common
 {
-    public $type = 'simple';
-    public $phase = PEAR_TASK_PACKAGEANDINSTALL;
-    public $_replacements;
+    var $type = 'simple';
+    var $phase = PEAR_TASK_PACKAGEANDINSTALL;
+    var $_replacements;
 
     /**
      * Validate the raw xml at parsing-time.
-     *
-     * @param  PEAR_PackageFile_v2
-     * @param  array raw, parsed xml
-     * @param  PEAR_Config
+     * @param PEAR_PackageFile_v2
+     * @param array raw, parsed xml
+     * @param PEAR_Config
      * @static
      */
-    public function validateXml($pkg, $xml, $config, $fileXml)
+    function validateXml($pkg, $xml, $config, $fileXml)
     {
         if (!isset($xml['attribs'])) {
             return array(PEAR_TASK_ERROR_NOATTRIBS);
@@ -59,36 +58,33 @@ class PEAR_Task_Replace extends PEAR_Task_Common
         if ($xml['attribs']['type'] == 'pear-config') {
             if (!in_array($xml['attribs']['to'], $config->getKeys())) {
                 return array(PEAR_TASK_ERROR_WRONG_ATTRIB_VALUE, 'to', $xml['attribs']['to'],
-                    $config->getKeys(), );
+                    $config->getKeys());
             }
         } elseif ($xml['attribs']['type'] == 'php-const') {
             if (defined($xml['attribs']['to'])) {
                 return true;
             } else {
                 return array(PEAR_TASK_ERROR_WRONG_ATTRIB_VALUE, 'to', $xml['attribs']['to'],
-                    array('valid PHP constant'), );
+                    array('valid PHP constant'));
             }
         } elseif ($xml['attribs']['type'] == 'package-info') {
-            if (in_array(
-                $xml['attribs']['to'],
+            if (in_array($xml['attribs']['to'],
                 array('name', 'summary', 'channel', 'notes', 'extends', 'description',
                     'release_notes', 'license', 'release-license', 'license-uri',
                     'version', 'api-version', 'state', 'api-state', 'release_date',
-                    'date', 'time', )
-            )) {
+                    'date', 'time'))) {
                 return true;
             } else {
                 return array(PEAR_TASK_ERROR_WRONG_ATTRIB_VALUE, 'to', $xml['attribs']['to'],
                     array('name', 'summary', 'channel', 'notes', 'extends', 'description',
                     'release_notes', 'license', 'release-license', 'license-uri',
                     'version', 'api-version', 'state', 'api-state', 'release_date',
-                    'date', 'time', ), );
+                    'date', 'time'));
             }
         } else {
             return array(PEAR_TASK_ERROR_WRONG_ATTRIB_VALUE, 'type', $xml['attribs']['type'],
-                array('pear-config', 'package-info', 'php-const'), );
+                array('pear-config', 'package-info', 'php-const'));
         }
-
         return true;
     }
 
@@ -97,7 +93,7 @@ class PEAR_Task_Replace extends PEAR_Task_Common
      * @param array raw, parsed xml
      * @param unused
      */
-    public function init($xml, $attribs)
+    function init($xml, $attribs)
     {
         $this->_replacements = isset($xml['attribs']) ? array($xml) : $xml;
     }
@@ -106,14 +102,13 @@ class PEAR_Task_Replace extends PEAR_Task_Common
      * Do a package.xml 1.0 replacement, with additional package-info fields available
      *
      * See validateXml() source for the complete list of allowed fields
-     *
-     * @param  PEAR_PackageFile_v1|PEAR_PackageFile_v2
-     * @param  string file contents
-     * @param  string the eventual final file location (informational only)
+     * @param PEAR_PackageFile_v1|PEAR_PackageFile_v2
+     * @param string file contents
+     * @param string the eventual final file location (informational only)
      * @return string|false|PEAR_Error false to skip this file, PEAR_Error to fail
-     *                                 (use $this->throwError), otherwise return the new contents
+     *         (use $this->throwError), otherwise return the new contents
      */
-    public function startSession($pkg, $contents, $dest)
+    function startSession($pkg, $contents, $dest)
     {
         $subst_from = $subst_to = array();
         foreach ($this->_replacements as $a) {
@@ -129,7 +124,6 @@ class PEAR_Task_Replace extends PEAR_Task_Common
                         $to = $chan->getServer();
                     } else {
                         $this->logger->log(0, "$dest: invalid pear-config replacement: $a[to]");
-
                         return false;
                     }
                 } else {
@@ -146,7 +140,6 @@ class PEAR_Task_Replace extends PEAR_Task_Common
                 }
                 if (is_null($to)) {
                     $this->logger->log(0, "$dest: invalid pear-config replacement: $a[to]");
-
                     return false;
                 }
             } elseif ($a['type'] == 'php-const') {
@@ -157,7 +150,6 @@ class PEAR_Task_Replace extends PEAR_Task_Common
                     $to = constant($a['to']);
                 } else {
                     $this->logger->log(0, "$dest: invalid php-const replacement: $a[to]");
-
                     return false;
                 }
             } else {
@@ -165,7 +157,6 @@ class PEAR_Task_Replace extends PEAR_Task_Common
                     $to = $t;
                 } else {
                     $this->logger->log(0, "$dest: invalid package-info replacement: $a[to]");
-
                     return false;
                 }
             }
@@ -174,14 +165,12 @@ class PEAR_Task_Replace extends PEAR_Task_Common
                 $subst_to[] = $to;
             }
         }
-        $this->logger->log(
-            3, "doing ".sizeof($subst_from).
-            " substitution(s) for $dest"
-        );
+        $this->logger->log(3, "doing " . sizeof($subst_from) .
+            " substitution(s) for $dest");
         if (sizeof($subst_from)) {
             $contents = str_replace($subst_from, $subst_to, $contents);
         }
-
         return $contents;
     }
 }
+?>

--- a/PEAR/Task/Replace/rw.php
+++ b/PEAR/Task/Replace/rw.php
@@ -30,7 +30,7 @@ require_once 'PEAR/Task/Replace.php';
  */
 class PEAR_Task_Replace_rw extends PEAR_Task_Replace
 {
-    public function PEAR_Task_Replace_rw(&$pkg, &$config, &$logger, $fileXml)
+    public function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
         parent::PEAR_Task_Common($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;

--- a/PEAR/Task/Replace/rw.php
+++ b/PEAR/Task/Replace/rw.php
@@ -32,7 +32,7 @@ class PEAR_Task_Replace_rw extends PEAR_Task_Replace
 {
     public function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
-        parent::PEAR_Task_Common($config, $logger, PEAR_TASK_PACKAGE);
+        parent::__construct($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;
         $this->_pkg = &$pkg;
         $this->_params = array();

--- a/PEAR/Task/Replace/rw.php
+++ b/PEAR/Task/Replace/rw.php
@@ -4,14 +4,14 @@
  *
  * PHP versions 4 and 5
  *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   CVS: $Id$
- * @link      http://pear.php.net/package/PEAR
- * @since     File available since Release 1.4.0a10
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    CVS: $Id$
+ * @link       http://pear.php.net/package/PEAR
+ * @since      File available since Release 1.4.0a10
  */
 /**
  * Base class
@@ -30,7 +30,7 @@ require_once 'PEAR/Task/Replace.php';
  */
 class PEAR_Task_Replace_rw extends PEAR_Task_Replace
 {
-    public function __construct(&$pkg, &$config, &$logger, $fileXml)
+    function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
         parent::__construct($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;
@@ -38,23 +38,24 @@ class PEAR_Task_Replace_rw extends PEAR_Task_Replace
         $this->_params = array();
     }
 
-    public function validate()
+    function validate()
     {
         return $this->validateXml($this->_pkg, $this->_params, $this->config, $this->_contents);
     }
 
-    public function setInfo($from, $to, $type)
+    function setInfo($from, $to, $type)
     {
         $this->_params = array('attribs' => array('from' => $from, 'to' => $to, 'type' => $type));
     }
 
-    public function getName()
+    function getName()
     {
         return 'replace';
     }
 
-    public function getXml()
+    function getXml()
     {
         return $this->_params;
     }
 }
+?>

--- a/PEAR/Task/Unixeol.php
+++ b/PEAR/Task/Unixeol.php
@@ -4,14 +4,14 @@
  *
  * PHP versions 4 and 5
  *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   CVS: $Id$
- * @link      http://pear.php.net/package/PEAR
- * @since     File available since Release 1.4.0a1
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    CVS: $Id$
+ * @link       http://pear.php.net/package/PEAR
+ * @since      File available since Release 1.4.0a1
  */
 /**
  * Base class
@@ -30,24 +30,22 @@ require_once 'PEAR/Task/Common.php';
  */
 class PEAR_Task_Unixeol extends PEAR_Task_Common
 {
-    public $type = 'simple';
-    public $phase = PEAR_TASK_PACKAGE;
-    public $_replacements;
+    var $type = 'simple';
+    var $phase = PEAR_TASK_PACKAGE;
+    var $_replacements;
 
     /**
      * Validate the raw xml at parsing-time.
-     *
-     * @param  PEAR_PackageFile_v2
-     * @param  array raw, parsed xml
-     * @param  PEAR_Config
+     * @param PEAR_PackageFile_v2
+     * @param array raw, parsed xml
+     * @param PEAR_Config
      * @static
      */
-    public function validateXml($pkg, $xml, $config, $fileXml)
+    function validateXml($pkg, $xml, $config, $fileXml)
     {
         if ($xml != '') {
             return array(PEAR_TASK_ERROR_INVALID, 'no attributes allowed');
         }
-
         return true;
     }
 
@@ -56,7 +54,7 @@ class PEAR_Task_Unixeol extends PEAR_Task_Common
      * @param array raw, parsed xml
      * @param unused
      */
-    public function init($xml, $attribs)
+    function init($xml, $attribs)
     {
     }
 
@@ -64,17 +62,16 @@ class PEAR_Task_Unixeol extends PEAR_Task_Common
      * Replace all line endings with line endings customized for the current OS
      *
      * See validateXml() source for the complete list of allowed fields
-     *
-     * @param  PEAR_PackageFile_v1|PEAR_PackageFile_v2
-     * @param  string file contents
-     * @param  string the eventual final file location (informational only)
+     * @param PEAR_PackageFile_v1|PEAR_PackageFile_v2
+     * @param string file contents
+     * @param string the eventual final file location (informational only)
      * @return string|false|PEAR_Error false to skip this file, PEAR_Error to fail
-     *                                 (use $this->throwError), otherwise return the new contents
+     *         (use $this->throwError), otherwise return the new contents
      */
-    public function startSession($pkg, $contents, $dest)
+    function startSession($pkg, $contents, $dest)
     {
         $this->logger->log(3, "replacing all line endings with \\n in $dest");
-
         return preg_replace("/\r\n|\n\r|\r|\n/", "\n", $contents);
     }
 }
+?>

--- a/PEAR/Task/Unixeol/rw.php
+++ b/PEAR/Task/Unixeol/rw.php
@@ -30,7 +30,7 @@ require_once 'PEAR/Task/Unixeol.php';
  */
 class PEAR_Task_Unixeol_rw extends PEAR_Task_Unixeol
 {
-    public function PEAR_Task_Unixeol_rw(&$pkg, &$config, &$logger, $fileXml)
+    public function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
         parent::PEAR_Task_Common($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;

--- a/PEAR/Task/Unixeol/rw.php
+++ b/PEAR/Task/Unixeol/rw.php
@@ -32,7 +32,7 @@ class PEAR_Task_Unixeol_rw extends PEAR_Task_Unixeol
 {
     public function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
-        parent::PEAR_Task_Common($config, $logger, PEAR_TASK_PACKAGE);
+        parent::__construct($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;
         $this->_pkg = &$pkg;
         $this->_params = array();

--- a/PEAR/Task/Unixeol/rw.php
+++ b/PEAR/Task/Unixeol/rw.php
@@ -4,14 +4,14 @@
  *
  * PHP versions 4 and 5
  *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   CVS: $Id$
- * @link      http://pear.php.net/package/PEAR
- * @since     File available since Release 1.4.0a10
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    CVS: $Id$
+ * @link       http://pear.php.net/package/PEAR
+ * @since      File available since Release 1.4.0a10
  */
 /**
  * Base class
@@ -30,7 +30,7 @@ require_once 'PEAR/Task/Unixeol.php';
  */
 class PEAR_Task_Unixeol_rw extends PEAR_Task_Unixeol
 {
-    public function __construct(&$pkg, &$config, &$logger, $fileXml)
+    function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
         parent::__construct($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;
@@ -38,18 +38,19 @@ class PEAR_Task_Unixeol_rw extends PEAR_Task_Unixeol
         $this->_params = array();
     }
 
-    public function validate()
+    function validate()
     {
         return true;
     }
 
-    public function getName()
+    function getName()
     {
         return 'unixeol';
     }
 
-    public function getXml()
+    function getXml()
     {
         return '';
     }
 }
+?>

--- a/PEAR/Task/Windowseol.php
+++ b/PEAR/Task/Windowseol.php
@@ -4,14 +4,14 @@
  *
  * PHP versions 4 and 5
  *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   CVS: $Id$
- * @link      http://pear.php.net/package/PEAR
- * @since     File available since Release 1.4.0a1
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    CVS: $Id$
+ * @link       http://pear.php.net/package/PEAR
+ * @since      File available since Release 1.4.0a1
  */
 /**
  * Base class
@@ -19,36 +19,33 @@
 require_once 'PEAR/Task/Common.php';
 /**
  * Implements the windows line endsings file task.
- *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   Release: @package_version@
- * @link      http://pear.php.net/package/PEAR
- * @since     Class available since Release 1.4.0a1
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    Release: @package_version@
+ * @link       http://pear.php.net/package/PEAR
+ * @since      Class available since Release 1.4.0a1
  */
 class PEAR_Task_Windowseol extends PEAR_Task_Common
 {
-    public $type = 'simple';
-    public $phase = PEAR_TASK_PACKAGE;
-    public $_replacements;
+    var $type = 'simple';
+    var $phase = PEAR_TASK_PACKAGE;
+    var $_replacements;
 
     /**
      * Validate the raw xml at parsing-time.
-     *
-     * @param  PEAR_PackageFile_v2
-     * @param  array raw, parsed xml
-     * @param  PEAR_Config
+     * @param PEAR_PackageFile_v2
+     * @param array raw, parsed xml
+     * @param PEAR_Config
      * @static
      */
-    public function validateXml($pkg, $xml, $config, $fileXml)
+    function validateXml($pkg, $xml, $config, $fileXml)
     {
         if ($xml != '') {
             return array(PEAR_TASK_ERROR_INVALID, 'no attributes allowed');
         }
-
         return true;
     }
 
@@ -57,7 +54,7 @@ class PEAR_Task_Windowseol extends PEAR_Task_Common
      * @param array raw, parsed xml
      * @param unused
      */
-    public function init($xml, $attribs)
+    function init($xml, $attribs)
     {
     }
 
@@ -65,17 +62,16 @@ class PEAR_Task_Windowseol extends PEAR_Task_Common
      * Replace all line endings with windows line endings
      *
      * See validateXml() source for the complete list of allowed fields
-     *
-     * @param  PEAR_PackageFile_v1|PEAR_PackageFile_v2
-     * @param  string file contents
-     * @param  string the eventual final file location (informational only)
+     * @param PEAR_PackageFile_v1|PEAR_PackageFile_v2
+     * @param string file contents
+     * @param string the eventual final file location (informational only)
      * @return string|false|PEAR_Error false to skip this file, PEAR_Error to fail
-     *                                 (use $this->throwError), otherwise return the new contents
+     *         (use $this->throwError), otherwise return the new contents
      */
-    public function startSession($pkg, $contents, $dest)
+    function startSession($pkg, $contents, $dest)
     {
         $this->logger->log(3, "replacing all line endings with \\r\\n in $dest");
-
         return preg_replace("/\r\n|\n\r|\r|\n/", "\r\n", $contents);
     }
 }
+?>

--- a/PEAR/Task/Windowseol/rw.php
+++ b/PEAR/Task/Windowseol/rw.php
@@ -33,7 +33,7 @@ class PEAR_Task_Windowseol_rw extends PEAR_Task_Windowseol
 {
     public function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
-        parent::PEAR_Task_Common($config, $logger, PEAR_TASK_PACKAGE);
+        parent::__construct($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;
         $this->_pkg = &$pkg;
         $this->_params = array();

--- a/PEAR/Task/Windowseol/rw.php
+++ b/PEAR/Task/Windowseol/rw.php
@@ -31,7 +31,7 @@ require_once 'PEAR/Task/Windowseol.php';
  */
 class PEAR_Task_Windowseol_rw extends PEAR_Task_Windowseol
 {
-    public function PEAR_Task_Windowseol_rw(&$pkg, &$config, &$logger, $fileXml)
+    public function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
         parent::PEAR_Task_Common($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;

--- a/PEAR/Task/Windowseol/rw.php
+++ b/PEAR/Task/Windowseol/rw.php
@@ -4,14 +4,14 @@
  *
  * PHP versions 4 and 5
  *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   CVS: $Id$
- * @link      http://pear.php.net/package/PEAR
- * @since     File available since Release 1.4.0a10
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    CVS: $Id$
+ * @link       http://pear.php.net/package/PEAR
+ * @since      File available since Release 1.4.0a10
  */
 /**
  * Base class
@@ -19,19 +19,18 @@
 require_once 'PEAR/Task/Windowseol.php';
 /**
  * Abstracts the windowseol task xml.
- *
- * @category  pear
- * @package   PEAR
- * @author    Greg Beaver <cellog@php.net>
- * @copyright 1997-2009 The Authors
- * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   Release: @package_version@
- * @link      http://pear.php.net/package/PEAR
- * @since     Class available since Release 1.4.0a10
+ * @category   pear
+ * @package    PEAR
+ * @author     Greg Beaver <cellog@php.net>
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @version    Release: @package_version@
+ * @link       http://pear.php.net/package/PEAR
+ * @since      Class available since Release 1.4.0a10
  */
 class PEAR_Task_Windowseol_rw extends PEAR_Task_Windowseol
 {
-    public function __construct(&$pkg, &$config, &$logger, $fileXml)
+    function __construct(&$pkg, &$config, &$logger, $fileXml)
     {
         parent::__construct($config, $logger, PEAR_TASK_PACKAGE);
         $this->_contents = $fileXml;
@@ -39,18 +38,19 @@ class PEAR_Task_Windowseol_rw extends PEAR_Task_Windowseol
         $this->_params = array();
     }
 
-    public function validate()
+    function validate()
     {
         return true;
     }
 
-    public function getName()
+    function getName()
     {
         return 'windowseol';
     }
 
-    public function getXml()
+    function getXml()
     {
         return '';
     }
 }
+?>

--- a/tests/PEAR/pear1.phpt
+++ b/tests/PEAR/pear1.phpt
@@ -38,10 +38,6 @@ class Other extends Pear {
 
     var $a = 'default value';
 
-    function __construct() {
-        $this->__construct();
-    }
-
     function _Other() {
         // $a was modified but here misteriously returns to be
         // the original value. That makes the destructor useless

--- a/tests/PEAR/pear1.phpt
+++ b/tests/PEAR/pear1.phpt
@@ -38,7 +38,7 @@ class Other extends Pear {
 
     var $a = 'default value';
 
-    function Other() {
+    function __construct() {
         $this->__construct();
     }
 

--- a/tests/PEAR/pear1.phpt
+++ b/tests/PEAR/pear1.phpt
@@ -15,7 +15,7 @@ class TestPEAR extends PEAR {
     function __construct($name) {
         $this->_debug = true;
         $this->name = $name;
-        $this->PEAR();
+        parent::__construct();
     }
     function _TestPEAR() {
         print "This is the TestPEAR($this->name) destructor\n";

--- a/tests/PEAR/pear1.phpt
+++ b/tests/PEAR/pear1.phpt
@@ -12,7 +12,7 @@ if (!getenv('PHP_PEAR_RUNTESTS')) {
 require_once "PEAR.php";
 
 class TestPEAR extends PEAR {
-    function TestPEAR($name) {
+    function __construct($name) {
         $this->_debug = true;
         $this->name = $name;
         $this->PEAR();
@@ -39,7 +39,7 @@ class Other extends Pear {
     var $a = 'default value';
 
     function Other() {
-        $this->PEAR();
+        $this->__construct();
     }
 
     function _Other() {

--- a/tests/PEAR_Command_Install/bundle/packages/Archive_Tar/Archive/Tar.php
+++ b/tests/PEAR_Command_Install/bundle/packages/Archive_Tar/Archive/Tar.php
@@ -77,9 +77,9 @@ class Archive_Tar extends PEAR
     *                   boolean value 'true' means 'gz'.
     * @access public
     */
-    function __construct($p_tarname, $p_compress = null)
+    function Archive_Tar($p_tarname, $p_compress = null)
     {
-        parent::construct();
+        $this->PEAR();
         $this->_compress = false;
         $this->_compress_type = 'none';
         if ($p_compress === null) {
@@ -369,7 +369,7 @@ class Archive_Tar extends PEAR
             }
             $this->_close();
         }
-
+        
         if (!$this->_openAppend())
             return false;
 
@@ -504,12 +504,12 @@ class Archive_Tar extends PEAR
     function setAttribute()
     {
         $v_result = true;
-
+        
         // ----- Get the number of variable list of arguments
         if (($v_size = func_num_args()) == 0) {
             return true;
         }
-
+        
         // ----- Get the arguments
         $v_att_list = &func_get_args();
 
@@ -736,7 +736,7 @@ class Archive_Tar extends PEAR
       if (is_resource($this->_file)) {
           if ($p_len === null)
               $p_len = 512;
-
+              
           if ($this->_compress_type == 'gz')
               $v_block = @gzread($this->_file, 512);
           else if ($this->_compress_type == 'bz2')
@@ -1474,7 +1474,7 @@ class Archive_Tar extends PEAR
     {
         if (filesize($this->_tarname) == 0)
           return $this->_openWrite();
-
+          
         if ($this->_compress) {
             $this->_close();
 
@@ -1487,7 +1487,7 @@ class Archive_Tar extends PEAR
                 $v_temp_tar = @gzopen($this->_tarname.".tmp", "rb");
             elseif ($this->_compress_type == 'bz2')
                 $v_temp_tar = @bzopen($this->_tarname.".tmp", "rb");
-
+                
             if ($v_temp_tar == 0) {
                 $this->_error('Unable to open file \''.$this->_tarname.'.tmp\' in binary read mode');
                 @rename($this->_tarname.".tmp", $this->_tarname);
@@ -1550,7 +1550,7 @@ class Archive_Tar extends PEAR
     {
         if (!$this->_openAppend())
             return false;
-
+            
         if ($this->_addList($p_filelist, $p_add_dir, $p_remove_dir))
            $this->_writeFooter();
 

--- a/tests/PEAR_Command_Install/bundle/packages/Archive_Tar/Archive/Tar.php
+++ b/tests/PEAR_Command_Install/bundle/packages/Archive_Tar/Archive/Tar.php
@@ -77,9 +77,9 @@ class Archive_Tar extends PEAR
     *                   boolean value 'true' means 'gz'.
     * @access public
     */
-    function Archive_Tar($p_tarname, $p_compress = null)
+    function __construct($p_tarname, $p_compress = null)
     {
-        $this->PEAR();
+        parent::construct();
         $this->_compress = false;
         $this->_compress_type = 'none';
         if ($p_compress === null) {
@@ -369,7 +369,7 @@ class Archive_Tar extends PEAR
             }
             $this->_close();
         }
-        
+
         if (!$this->_openAppend())
             return false;
 
@@ -504,12 +504,12 @@ class Archive_Tar extends PEAR
     function setAttribute()
     {
         $v_result = true;
-        
+
         // ----- Get the number of variable list of arguments
         if (($v_size = func_num_args()) == 0) {
             return true;
         }
-        
+
         // ----- Get the arguments
         $v_att_list = &func_get_args();
 
@@ -736,7 +736,7 @@ class Archive_Tar extends PEAR
       if (is_resource($this->_file)) {
           if ($p_len === null)
               $p_len = 512;
-              
+
           if ($this->_compress_type == 'gz')
               $v_block = @gzread($this->_file, 512);
           else if ($this->_compress_type == 'bz2')
@@ -1474,7 +1474,7 @@ class Archive_Tar extends PEAR
     {
         if (filesize($this->_tarname) == 0)
           return $this->_openWrite();
-          
+
         if ($this->_compress) {
             $this->_close();
 
@@ -1487,7 +1487,7 @@ class Archive_Tar extends PEAR
                 $v_temp_tar = @gzopen($this->_tarname.".tmp", "rb");
             elseif ($this->_compress_type == 'bz2')
                 $v_temp_tar = @bzopen($this->_tarname.".tmp", "rb");
-                
+
             if ($v_temp_tar == 0) {
                 $this->_error('Unable to open file \''.$this->_tarname.'.tmp\' in binary read mode');
                 @rename($this->_tarname.".tmp", $this->_tarname);
@@ -1550,7 +1550,7 @@ class Archive_Tar extends PEAR
     {
         if (!$this->_openAppend())
             return false;
-            
+
         if ($this->_addList($p_filelist, $p_add_dir, $p_remove_dir))
            $this->_writeFooter();
 

--- a/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table.php
+++ b/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table.php
@@ -2,20 +2,20 @@
 
 /**
  * DB_Table is a database API and data type SQL abstraction class.
- * 
+ *
  * DB_Table provides database API abstraction, data type abstraction,
  * automated SELECT, INSERT, and UPDATE queries, automated table
  * creation, automated validation of inserted/updated column values,
  * and automated creation of QuickForm elements based on the column
  * definitions.
- * 
+ *
  * @category Database
  * @package DB_Table
  * @author Paul M. Jones <pmjones@php.net>
  * @author Mark Wiesemann <wiesemann@php.net>
- * 
+ *
  * @license http://www.gnu.org/copyleft/lesser.html LGPL
- * 
+ *
  * @version $Id: Table.php,v 1.87 2007/06/14 15:07:27 morse Exp $
  */
 
@@ -386,11 +386,11 @@ $GLOBALS['_DB_TABLE']['type'] = array(
 );
 
 
-/** 
+/**
  * US-English default error messages. If you want to internationalize, you can
  * set the translated messages via $GLOBALS['_DB_TABLE']['error']. You can also
  * use DB_Table::setErrorMessage(). Examples:
- * 
+ *
  * <code>
  * (1) $GLOBALS['_DB_TABLE]['error'] = array(DB_TABLE_ERR_PHPTYPE   => '...',
  *                                           DB_TABLE_ERR_SQL_UNDEF => '...');
@@ -405,7 +405,7 @@ $GLOBALS['_DB_TABLE']['type'] = array(
  *     $obj->setErrorMessage(array(DB_TABLE_ERR_PHPTYPE   => '...');
  *                                 DB_TABLE_ERR_SQL_UNDEF => '...');
  * </code>
- * 
+ *
  * For errors that can occur with-in the constructor call (i.e. e.g. creating
  * or altering the database table), only the code from examples (1) to (3)
  * will alter the default error messages early enough. For errors that can
@@ -464,36 +464,36 @@ foreach ($GLOBALS['_DB_TABLE']['default_error'] as $code => $message) {
 
 /**
  * DB_Table is a database API and data type SQL abstraction class.
- * 
+ *
  * DB_Table provides database API abstraction, data type abstraction,
  * automated SELECT, INSERT, and UPDATE queries, automated table
  * creation, automated validation of inserted/updated column values,
  * and automated creation of QuickForm elemnts based on the column
  * definitions.
- * 
+ *
  * @category Database
  * @package DB_Table
  * @author Paul M. Jones <pmjones@php.net>
  * @author Mark Wiesemann <wiesemann@php.net>
- * 
+ *
  * @version @package_version@
  *
  */
 
-class DB_Table extends DB_Table_Base 
+class DB_Table extends DB_Table_Base
 {
-    
+
     /**
      * The table or view in the database to which this object binds.
-     * 
+     *
      * @access public
      * @var string
      */
     var $table = null;
-    
+
     /**
      * DB_Table_Database instance that this table belongs to.
-     * 
+     *
      * @access private
      * @var object
      */
@@ -502,25 +502,25 @@ class DB_Table extends DB_Table_Base
 
     /**
      * Associative array of column definitions.
-     * 
+     *
      * @access public
      * @var array
      */
     var $col = array();
-    
-    
+
+
     /**
      * Associative array of index definitions.
-     * 
+     *
      * @access public
      * @var array
      */
     var $idx = array();
-    
+
     /**
      * Name of an auto-increment column, if any. Null otherwise.
      *
-     * A table can contain at most one auto-increment column. 
+     * A table can contain at most one auto-increment column.
      * Auto-incrementing is implemented in the insert() method,
      * using a sequence accessed by the nextID() method.
      *
@@ -532,7 +532,7 @@ class DB_Table extends DB_Table_Base
 
     /**
      * Boolean flag to turn on (true) or off (false) auto-incrementing.
-     * 
+     *
      * Auto-increment column $auto_inc_col upon insertion only if $_auto_inc is
      * true and the value of that column is null in the data to be inserted.
      *
@@ -544,30 +544,30 @@ class DB_Table extends DB_Table_Base
 
     /**
      * Whether or not to automatically validate data at insert-time.
-     * 
+     *
      * @var bool
      * @access private
      */
     var $_valid_insert = true;
-    
+
     /**
      * Whether or not to automatically validate data at update-time.
-     * 
+     *
      * @var bool
      * @access private
      */
     var $_valid_update = true;
-    
+
 
     /**
      * Whether or not to automatically recast data at insert- and update-time.
-     * 
+     *
      * @var    bool
      * @access private
      */
     var $_auto_recast = true;
-    
-    
+
+
     /**
      * Constructor.
      *
@@ -577,13 +577,13 @@ class DB_Table extends DB_Table_Base
      * or verify that its schema matches that declared in the $col and
      * $idx parameters, depending on the value of the $create parameter.
      *
-     * If there is an error on instantiation, $this->error will be 
+     * If there is an error on instantiation, $this->error will be
      * populated with the PEAR_Error.
-     * 
+     *
      * @param object &$db A PEAR DB/MDB2 object.
-     * 
+     *
      * @param string $table The table name to connect to in the database.
-     * 
+     *
      * @param mixed $create The automatic table creation mode to pursue:
      * - boolean false to not attempt creation
      * - 'safe' to create the table only if it does not exist
@@ -595,11 +595,11 @@ class DB_Table extends DB_Table_Base
      *   exists, a verification for columns existence, the column types, the
      *   indexes existence, and the indexes types will be performed and the
      *   table schema will be modified if needed
-     * 
+     *
      * @return object DB_Table
      * @access public
      */
-    function DB_Table(&$db, $table, $create = false)
+    function __construct(&$db, $table, $create = false)
     {
         // is the first argument a DB/MDB2 object?
         $this->backend = null;
@@ -613,14 +613,14 @@ class DB_Table extends DB_Table_Base
             $this->error =& DB_Table::throwError(DB_TABLE_ERR_NOT_DB_OBJECT);
             return;
         }
-        
+
         // set the class properties
         $this->db =& $db;
         $this->table = $table;
 
         // Identify the class for error handling by parent class
         $this->_primary_subclass = 'DB_TABLE';
-        
+
         // is the RDBMS supported?
         $phptype = $db->phptype;
         $dbsyntax = $db->dbsyntax;
@@ -675,7 +675,7 @@ class DB_Table extends DB_Table_Base
                     $result = $this->verify();
                     break;
             }
-            
+
             if (PEAR::isError($result)) {
                 // problem creating/altering/verifing the table
                 $this->error =& $result;
@@ -683,18 +683,18 @@ class DB_Table extends DB_Table_Base
             }
         }
     }
-    
-    
+
+
     /**
      * Is a particular RDBMS supported by DB_Table?
-     * 
+     *
      * @static
      * @param string $phptype The RDBMS type for PHP.
      * @param string $dbsyntax The chosen database syntax.
      * @return bool  True if supported, false if not.
      * @access public
      */
-    
+
     function supported($phptype, $dbsyntax = '')
     {
         // only Firebird is supported, not its ancestor Interbase
@@ -708,14 +708,14 @@ class DB_Table extends DB_Table_Base
 
     /**
      * Is a creation mode supported for a RDBMS by DB_Table?
-     * 
+     *
      * @param string $mode The chosen creation mode.
      * @param string $phptype The RDBMS type for PHP.
      * @return bool  True if supported, false if not (PEAR_Error on failure)
      *
      * @throws PEAR_Error if
      *     Unknown creation mode is specified (DB_TABLE_ERR_CREATE_FLAG)
-     * 
+     *
      * @access public
      */
     function modeSupported($mode, $phptype)
@@ -755,11 +755,11 @@ class DB_Table extends DB_Table_Base
 
     /**
      * Overwrite one or more error messages, e.g. to internationalize them.
-     * 
+     *
      * @param mixed $code If string, the error message with code $code will
      * be overwritten by $message. If array, the error messages with code
      * of each array key will be overwritten by the key's value.
-     * 
+     *
      * @param string $message Only used if $key is not an array.
      * @return void
      * @access public
@@ -776,9 +776,9 @@ class DB_Table extends DB_Table_Base
 
 
     /**
-     * 
+     *
      * Returns all or part of the $this->col property array.
-     * 
+     *
      * @param mixed $col If null, returns the $this->col property array
      * as it is.  If string, returns that column name from the $this->col
      * array. If an array, returns those columns named as the array
@@ -794,7 +794,7 @@ class DB_Table extends DB_Table_Base
         if (is_null($col)) {
             return $this->col;
         }
-        
+
         // if the param is a string, only return the column definition
         // named by the that string
         if (is_string($col)) {
@@ -804,7 +804,7 @@ class DB_Table extends DB_Table_Base
                 return false;
             }
         }
-        
+
         // if the param is a sequential array of column names,
         // return only those columns named in that array
         if (is_array($col)) {
@@ -812,28 +812,28 @@ class DB_Table extends DB_Table_Base
             foreach ($col as $name) {
                 $set[$name] = $this->getColumns($name);
             }
-            
+
             if (count($set) == 0) {
                 return false;
             } else {
                 return $set;
             }
         }
-        
+
         // param was not null, string, or array
         return false;
     }
-    
-    
+
+
     /**
      * Returns all or part of the $this->idx property array.
-     * 
+     *
      * @param mixed $idx Index name (key in $this->idx), or array of
      *                   index name strings.
-     * 
-     * @return mixed All or part of the $this->idx property array, 
+     *
+     * @return mixed All or part of the $this->idx property array,
      *               or boolean false if $idx is not null but invalid
-     * 
+     *
      * @access public
      */
     function getIndexes($idx = null)
@@ -842,7 +842,7 @@ class DB_Table extends DB_Table_Base
         if (is_null($idx)) {
             return $this->idx;
         }
-        
+
         // if the param is a string, only return the index definition
         // named by the that string
         if (is_string($idx)) {
@@ -852,7 +852,7 @@ class DB_Table extends DB_Table_Base
                 return false;
             }
         }
-        
+
         // if the param is a sequential array of index names,
         // return only those indexes named in that array
         if (is_array($idx)) {
@@ -860,31 +860,31 @@ class DB_Table extends DB_Table_Base
             foreach ($idx as $name) {
                 $set[$name] = $this->getIndexes($name);
             }
-            
+
             if (count($set) == 0) {
                 return false;
             } else {
                 return $set;
             }
         }
-        
+
         // param was not null, string, or array
         return false;
     }
-    
-    
+
+
     /**
      * Connect or disconnect a DB_Table_Database instance to this table
      * instance.
-     * 
+     *
      * Used to re-connect this DB_Table object to a parent DB_Table_Database
-     * object during unserialization. Can also disconnect if the $database 
-     * parameter is null. Use the DB_Table_Database::addTable method instead 
+     * object during unserialization. Can also disconnect if the $database
+     * parameter is null. Use the DB_Table_Database::addTable method instead
      * to add a table to a new DB_Table_Database.
-     * 
+     *
      * @param object &$database DB_Table_Database instance that this table
      *               belongs to (or null to disconnect from instance).
-     * 
+     *
      * @return void
      * @access public
      */
@@ -897,14 +897,14 @@ class DB_Table extends DB_Table_Base
         }
     }
 
-    
+
     /**
      * Inserts a single table row.
      *
      * Inserts data from associative array $data, in which keys are column
      * names and values are column values. All required columns (except an
      * auto-increment column) must be included in the data array. Columns
-     * values that are not set or null are inserted as SQL NULL values. 
+     * values that are not set or null are inserted as SQL NULL values.
      *
      * If an auto-increment column is declared (by setting $this->auto_inc_col),
      * and the value of that column in $data is not set or null, then a new
@@ -917,11 +917,11 @@ class DB_Table extends DB_Table_Base
      * will validates column types with validInsert() before insertion.
      *
      * @access public
-     * 
+     *
      * @param array $data An associative array of key-value pairs where
-     * the key is the column name and the value is the column value. 
-     * This is the data that will be inserted into the table.  
-     * 
+     * the key is the column name and the value is the column value.
+     * This is the data that will be inserted into the table.
+     *
      * @return mixed Void on success (PEAR_Error on failure)
      *
      * @throws PEAR_Error if:
@@ -935,9 +935,9 @@ class DB_Table extends DB_Table_Base
     function insert($data)
     {
         // Auto-increment if enabled and input value is null or not set
-        if ($this->_auto_inc 
-            && !is_null($this->auto_inc_col) 
-            && !isset($data[$this->auto_inc_col]) 
+        if ($this->_auto_inc
+            && !is_null($this->auto_inc_col)
+            && !isset($data[$this->auto_inc_col])
            ) {
             $column = $this->auto_inc_col;
             // check that the auto-increment column exists
@@ -946,7 +946,7 @@ class DB_Table extends DB_Table_Base
                         DB_TABLE_ERR_AUTO_INC_COL,
                         ": $column does not exist");
             }
-            // check that the column is integer 
+            // check that the column is integer
             if (!in_array($this->col[$column]['type'],
                            array('integer','smallint','bigint'))) {
                 return $this->throwError(
@@ -954,8 +954,8 @@ class DB_Table extends DB_Table_Base
                         ": $column is not an integer");
             }
             // check that the column is required
-            // Note: The insert method will replace a null input value 
-            // of $data[$column] with a sequence value. This makes 
+            // Note: The insert method will replace a null input value
+            // of $data[$column] with a sequence value. This makes
             // the column effectively 'not null'. This column must be
             // 'required' for consistency, to make this explicit.
             if (!$this->isRequired($column)) {
@@ -988,7 +988,7 @@ class DB_Table extends DB_Table_Base
         if ($this->_database) {
 
             $_database = $this->_database;
-  
+
             // Validate foreign key values (if enabled)
             if ($_database->_check_fkey) {
                $result = $_database->validForeignKeys($this->table, $data);
@@ -996,9 +996,9 @@ class DB_Table extends DB_Table_Base
                    return $result;
                }
             }
-    
+
         }
-       
+
         // Do insertion
         if ($this->backend == 'mdb2') {
             $result = $this->db->extended->autoExecute($this->table, $data,
@@ -1009,16 +1009,16 @@ class DB_Table extends DB_Table_Base
         }
         return $result;
     }
-    
-    
+
+
     /**
      * Turns on or off auto-incrementing of $auto_inc_col column (if any)
-     * 
+     *
      * For auto-incrementing to work, an $auto_inc_col column must be declared,
      * auto-incrementing must be enabled (by this method), and the value of
      * the $auto_inc_col column must be not set or null in the $data passed to
-     * the insert method. 
-     * 
+     * the insert method.
+     *
      * @param  bool $flag True to turn on auto-increment, false to turn off.
      * @return void
      * @access public
@@ -1031,13 +1031,13 @@ class DB_Table extends DB_Table_Base
             $this->_auto_inc = false;
         }
     }
-    
-    
+
+
     /**
      * Turns on (or off) automatic validation of inserted data.
-     * 
-     * Enables (if $flag is true) or disables (if $flag is false) automatic 
-     * validation of data types prior to actual insertion into the database 
+     *
+     * Enables (if $flag is true) or disables (if $flag is false) automatic
+     * validation of data types prior to actual insertion into the database
      * by the DB_Table::insert() method.
      *
      * @param  bool $flag True to turn on auto-validation, false to turn off.
@@ -1052,16 +1052,16 @@ class DB_Table extends DB_Table_Base
             $this->_valid_insert = false;
         }
     }
-    
-    
+
+
     /**
      * Validates an array for insertion into the table.
-     * 
+     *
      * @param array $data An associative array of key-value pairs where
      * the key is the column name and the value is the column value.  This
      * is the data that will be inserted into the table.  Data is checked
      * against the column data type for validity.
-     * 
+     *
      * @return boolean true on success (PEAR_Error on failure)
      *
      * @throws PEAR_Error if:
@@ -1070,7 +1070,7 @@ class DB_Table extends DB_Table_Base
      *     - Column value doesn't match type  (DB_TABLE_ERR_INS_DATA_INVALID)
      *
      * @access public
-     * 
+     *
      * @see insert()
      */
     function validInsert(&$data)
@@ -1085,13 +1085,13 @@ class DB_Table extends DB_Table_Base
                 );
             }
         }
-        
+
         // loop through each column mapping, and check the data to be
         // inserted into it against the column data type. we loop through
         // column mappings instead of the insert data to make sure that
         // all necessary columns are being inserted.
         foreach ($this->col as $col => $val) {
-            
+
             // is the value allowed to be null?
             if (isset($val['require']) &&
                 $val['require'] == true &&
@@ -1101,7 +1101,7 @@ class DB_Table extends DB_Table_Base
                     "'$col'"
                 );
             }
-            
+
             // does the value to be inserted match the column data type?
             if (isset($data[$col]) &&
                 ! $this->isValid($data[$col], $col)) {
@@ -1111,31 +1111,31 @@ class DB_Table extends DB_Table_Base
                 );
             }
         }
-        
+
         return true;
     }
-    
-    
+
+
     /**
      * Update table row or rows that match a custom WHERE clause
      *
      * Constructs and submits an SQL UPDATE command to update columns whose
      * names are keys in the $data array parameter, in all rows that match
      * the logical condition given by the $where string parameter.
-     * 
+     *
      * If auto-recasting is enabled (if $this->_auto_recast), update() will
      * try, if necessary, to recast $data to proper column types, with recast().
      *
-     * If auto-validation is enabled (if $this->_valid_insert), update() 
+     * If auto-validation is enabled (if $this->_valid_insert), update()
      * validates column types with validUpdate() before insertion.
      *
      * @param array $data An associative array of key-value pairs where the
      * key is the column name and the value is the column value. These are
      * the columns that will be updated with new values.
-     * 
+     *
      * @param string $where An SQL WHERE clause limiting which records are
      * are to be updated.
-     * 
+     *
      * @return mixed Void on success, a PEAR_Error object on failure.
      *
      * @throws PEAR_Error if:
@@ -1143,7 +1143,7 @@ class DB_Table extends DB_Table_Base
      *     - Error thrown by DB/MDB2::autoexecute()
      *
      * @access public
-     * 
+     *
      * @see validUpdate()
      * @see DB::autoExecute()
      * @see MDB2::autoExecute()
@@ -1154,7 +1154,7 @@ class DB_Table extends DB_Table_Base
         if ($this->_auto_recast) {
             $this->recast($data);
         }
-        
+
         // validate the data if auto-validation is turned on
         if ($this->_valid_update) {
             $result = $this->validUpdate($data);
@@ -1165,7 +1165,7 @@ class DB_Table extends DB_Table_Base
 
         // Does a parent DB_Table_Database object exist?
         if ($this->_database) {
-  
+
             $_database =& $this->_database;
 
             // Validate foreign key values (if enabled)
@@ -1173,9 +1173,9 @@ class DB_Table extends DB_Table_Base
                $result = $_database->validForeignKeys($this->table, $data);
                if (PEAR::isError($result)) {
                    return $result;
-               } 
+               }
             }
-    
+
             // Implement any relevant ON UPDATE actions
             $result = $_database->onUpdateAction($this, $data, $where);
             if (PEAR::isError($result)) {
@@ -1183,8 +1183,8 @@ class DB_Table extends DB_Table_Base
             }
 
         }
-       
-        // Submit update command 
+
+        // Submit update command
         if ($this->backend == 'mdb2') {
             $result = $this->db->extended->autoExecute($this->table, $data,
                 MDB2_AUTOQUERY_UPDATE, $where);
@@ -1195,12 +1195,12 @@ class DB_Table extends DB_Table_Base
         return $result;
 
     }
-    
-    
+
+
     /**
      * Turns on (or off) automatic validation of updated data.
-     * 
-     * Enables (if $flag is true) or disables (if $flag is false) automatic 
+     *
+     * Enables (if $flag is true) or disables (if $flag is false) automatic
      * validation of data types prior to updating rows in the database by
      * the {@link update()} method.
      *
@@ -1216,16 +1216,16 @@ class DB_Table extends DB_Table_Base
             $this->_valid_update = false;
         }
     }
-    
-    
+
+
     /**
      * Validates an array for updating the table.
-     * 
+     *
      * @param array $data An associative array of key-value pairs where
      * the key is the column name and the value is the column value.  This
      * is the data that will be inserted into the table.  Data is checked
      * against the column data type for validity.
-     * 
+     *
      * @return mixed Boolean true on success (PEAR_Error object on failure)
      *
      * @throws PEAR_Error if
@@ -1234,7 +1234,7 @@ class DB_Table extends DB_Table_Base
      *     - Column value doesn't match type  (DB_TABLE_ERR_UPD_DATA_INVALID)
      *
      * @access public
-     * 
+     *
      * @see update()
      */
     function validUpdate(&$data)
@@ -1242,7 +1242,7 @@ class DB_Table extends DB_Table_Base
         // loop through each data element, and check the
         // data to be updated against the column data type.
         foreach ($data as $col => $val) {
-            
+
             // does the column exist?
             if (! isset($this->col[$col])) {
                 return $this->throwError(
@@ -1250,10 +1250,10 @@ class DB_Table extends DB_Table_Base
                     "('$col')"
                 );
             }
-            
+
             // the column definition
             $defn = $this->col[$col];
-            
+
             // is it allowed to be null?
             if (isset($defn['require']) &&
                 $defn['require'] == true &&
@@ -1264,7 +1264,7 @@ class DB_Table extends DB_Table_Base
                     $col
                 );
             }
-            
+
             // does the value to be inserted match the column data type?
             if (! $this->isValid($data[$col], $col)) {
                 return $this->throwError(
@@ -1273,22 +1273,22 @@ class DB_Table extends DB_Table_Base
                 );
             }
         }
-        
+
         return true;
     }
-    
-    
+
+
     /**
      * Deletes table rows matching a custom WHERE clause.
-     * 
-     * Constructs and submits and SQL DELETE command with the specified WHERE 
+     *
+     * Constructs and submits and SQL DELETE command with the specified WHERE
      * clause. Command is submitted by DB::query() or MDB2::exec().
      *
      * If a reference to a DB_Table_Database instance exists, carry out any
-     * ON DELETE actions declared in that instance before actual insertion, 
+     * ON DELETE actions declared in that instance before actual insertion,
      * if emulation of ON DELETE actions is enabled in that instance.
      *
-     * @param string $where Logical condition in the WHERE clause of the 
+     * @param string $where Logical condition in the WHERE clause of the
      *                      delete command.
      *
      * @return mixed void on success (PEAR_Error on failure)
@@ -1297,7 +1297,7 @@ class DB_Table extends DB_Table_Base
      *     DB::query() or MDB2::exec() returns error (bubbles up)
      *
      * @access public
-     * 
+     *
      * @see DB::query()
      * @see MDB2::exec()
      */
@@ -1305,7 +1305,7 @@ class DB_Table extends DB_Table_Base
     {
         // Does a parent DB_Table_Database object exist?
         if ($this->_database) {
-  
+
             $_database =& $this->_database;
 
             // Implement any relevant ON DELETE actions
@@ -1315,7 +1315,7 @@ class DB_Table extends DB_Table_Base
             }
 
         }
-       
+
         if ($this->backend == 'mdb2') {
             $result = $this->db->exec("DELETE FROM $this->table WHERE $where");
         } else {
@@ -1323,24 +1323,24 @@ class DB_Table extends DB_Table_Base
         }
         return $result;
     }
-    
-    
+
+
     /**
      *
      * Generates and returns a sequence value.
      *
      * Generates a sequence value by calling the DB or MDB2::nextID() method. The
      * sequence name defaults to the table name, or may be specified explicitly.
-     * 
+     *
      * @param  string  $seq_name The sequence name; defaults to table_id.
-     * 
+     *
      * @return integer The next value in the sequence (PEAR_Error on failure)
      *
      * @throws PEAR_Error if
      *     Sequence name too long (>26 char + _seq) (DB_TABLE_ERR_SEQ_STRLEN)
      *
      * @access public
-     * 
+     *
      * @see DB::nextID()
      * @see MDB2::nextID()
      */
@@ -1351,7 +1351,7 @@ class DB_Table extends DB_Table_Base
         } else {
             $seq_name = "{$this->table}_{$seq_name}";
         }
-        
+
         // the maximum length is 30, but PEAR DB/MDB2 will add "_seq" to the
         // name, so the max length here is less 4 chars. we have to
         // check here because the sequence will be created automatically
@@ -1361,29 +1361,29 @@ class DB_Table extends DB_Table_Base
                 DB_TABLE_ERR_SEQ_STRLEN,
                 " ('$seq_name')"
             );
-            
+
         }
         return $this->db->nextId($seq_name);
     }
-    
-    
+
+
     /**
      * Escapes and enquotes a value for use in an SQL query.
-     * 
-     * Simple wrapper for DB_Common::quoteSmart() or MDB2::quote(), which 
-     * returns the value of one of these functions. Helps makes user input 
+     *
+     * Simple wrapper for DB_Common::quoteSmart() or MDB2::quote(), which
+     * returns the value of one of these functions. Helps makes user input
      * safe against SQL injection attack.
-     * 
+     *
      * @param mixed $val The value to be quoted
      *
-     * @return string The value with quotes escaped, inside single quotes if 
+     * @return string The value with quotes escaped, inside single quotes if
      *                non-numeric.
      *
      * @throws PEAR_Error if
      *     DB_Common::quoteSmart() or MDB2::quote() returns Error (bubbled up)
-     * 
+     *
      * @access public
-     * 
+     *
      * @see DB_Common::quoteSmart()
      * @see MDB2::quote()
      */
@@ -1396,13 +1396,13 @@ class DB_Table extends DB_Table_Base
         }
         return $val;
     }
-    
-    
+
+
     /**
      * Returns a blank row array based on the column map.
-     * 
+     *
      * The array keys are the column names, and all values are set to null.
-     * 
+     *
      * @return array An associative array where keys are column names and
      *               all values are null.
      * @access public
@@ -1410,25 +1410,25 @@ class DB_Table extends DB_Table_Base
     function getBlankRow()
     {
         $row = array();
-        
+
         foreach ($this->col as $key => $val) {
             $row[$key] = null;
         }
-        
+
         $this->recast($row);
-        
+
         return $row;
     }
-    
-    
+
+
     /**
      * Turns on (or off) automatic recasting of insert and update data.
-     * 
-     * Turns on (if $flag is true) or off (if $flag is false) automatic forcible 
-     * recasting of data to the declared data type, if required, prior to inserting 
-     * or updating.  The recasting is done by calling the DB_Table::recast() 
+     *
+     * Turns on (if $flag is true) or off (if $flag is false) automatic forcible
+     * recasting of data to the declared data type, if required, prior to inserting
+     * or updating.  The recasting is done by calling the DB_Table::recast()
      * method from within the DB_Table::insert() and DB_Table::update().
-     * 
+     *
      * @param bool $flag True to automatically recast insert and update data,
      *                   false to not do so.
      * @return void
@@ -1442,44 +1442,44 @@ class DB_Table extends DB_Table_Base
             $this->_auto_recast = false;
         }
     }
-    
-    
+
+
     /**
      * Forces array elements to the proper types for their columns.
-     * 
+     *
      * This will not valiate the data, and will forcibly change the data
      * to match the recast-type.
-     * 
+     *
      * The date, time, and timestamp recasting has special logic for
      * arrays coming from an HTML_QuickForm object so that the arrays
      * are converted into properly-formatted strings.
-     * 
+     *
      * @todo If a column key holds an array of values (say from a multiple
      * select) then this method will not work properly; it will recast the
      * value to the string 'Array'.  Is this bad?
-     * 
+     *
      * @param array   &$data The data array to re-cast.
-     * 
+     *
      * @return void
-     * 
+     *
      * @access public
      */
     function recast(&$data)
     {
         $keys = array_keys($data);
-        
+
         $null_if_blank = array('date', 'time', 'timestamp', 'smallint',
             'integer', 'bigint', 'decimal', 'single', 'double');
-        
+
         foreach ($keys as $key) {
-        
+
             if (! isset($this->col[$key])) {
                 continue;
             }
-            
+
             unset($val);
             $val =& $data[$key];
-            
+
             // convert blanks to null for non-character field types
             $convert = in_array($this->col[$key]['type'], $null_if_blank);
             if (is_array($val)) {  // if one of the given array values is
@@ -1502,25 +1502,25 @@ class DB_Table extends DB_Table_Base
             ) {
                 $val = null;
             }
-            
+
             // skip explicit NULL values
             if (is_null($val)) {
                 continue;
             }
-            
+
             // otherwise, recast to the column type
             switch ($this->col[$key]['type']) {
-            
+
             case 'boolean':
                 $val = ($val) ? 1 : 0;
                 break;
-                
+
             case 'char':
             case 'varchar':
             case 'clob':
                 settype($val, 'string');
                 break;
-                
+
             case 'date':
 
                 // smart handling of non-standard (i.e. Y-m-d) date formats,
@@ -1543,61 +1543,61 @@ class DB_Table extends DB_Table_Base
                     isset($val['Y']) &&
                     isset($val['m']) &&
                     isset($val['d'])) {
-                    
+
                     // the date is in HTML_QuickForm format,
                     // convert into a string
                     $y = (strlen($val['Y']) < 4)
                         ? str_pad($val['Y'], 4, '0', STR_PAD_LEFT)
                         : $val['Y'];
-                    
+
                     $m = (strlen($val['m']) < 2)
                         ? '0'.$val['m'] : $val['m'];
-                        
+
                     $d = (strlen($val['d']) < 2)
                         ? '0'.$val['d'] : $val['d'];
-                        
+
                     $val = "$y-$m-$d";
-                    
+
                 } else {
-                
+
                     // convert using the Date class
                     $tmp =& new DB_Table_Date($val);
                     $val = $tmp->format('%Y-%m-%d');
-                    
+
                 }
-                
+
                 break;
-            
+
             case 'time':
-            
+
                 if (is_array($val) &&
                     isset($val['H']) &&
                     isset($val['i']) &&
                     isset($val['s'])) {
-                    
+
                     // the time is in HTML_QuickForm format,
                     // convert into a string
                     $h = (strlen($val['H']) < 2)
                         ? '0' . $val['H'] : $val['H'];
-                    
+
                     $i = (strlen($val['i']) < 2)
                         ? '0' . $val['i'] : $val['i'];
-                        
+
                     $s = (strlen($val['s']) < 2)
                         ? '0' . $val['s'] : $val['s'];
-                        
-                        
+
+
                     $val = "$h:$i:$s";
-                    
+
                 } else {
                     // date does not matter in this case, so
                     // pre 1970 and post 2040 are not an issue.
                     $tmp = strtotime(date('Y-m-d') . " $val");
                     $val = date('H:i:s', $tmp);
                 }
-                
+
                 break;
-                
+
             case 'timestamp':
 
                 // smart handling of non-standard (i.e. Y-m-d) date formats,
@@ -1623,46 +1623,46 @@ class DB_Table extends DB_Table_Base
                     isset($val['H']) &&
                     isset($val['i']) &&
                     isset($val['s'])) {
-                    
+
                     // timestamp is in HTML_QuickForm format,
                     // convert each element to a string. pad
                     // with zeroes as needed.
-                
+
                     $y = (strlen($val['Y']) < 4)
                         ? str_pad($val['Y'], 4, '0', STR_PAD_LEFT)
                         : $val['Y'];
-                    
+
                     $m = (strlen($val['m']) < 2)
                         ? '0'.$val['m'] : $val['m'];
-                        
+
                     $d = (strlen($val['d']) < 2)
                         ? '0'.$val['d'] : $val['d'];
-                        
+
                     $h = (strlen($val['H']) < 2)
                         ? '0' . $val['H'] : $val['H'];
-                    
+
                     $i = (strlen($val['i']) < 2)
                         ? '0' . $val['i'] : $val['i'];
-                        
+
                     $s = (strlen($val['s']) < 2)
                         ? '0' . $val['s'] : $val['s'];
-                        
+
                     $val = "$y-$m-$d $h:$i:$s";
-                    
+
                 } else {
                     // convert using the Date class
                     $tmp =& new DB_Table_Date($val);
                     $val = $tmp->format('%Y-%m-%d %H:%M:%S');
                 }
-                
+
                 break;
-            
+
             case 'smallint':
             case 'integer':
             case 'bigint':
                 settype($val, 'integer');
                 break;
-            
+
             case 'decimal':
             case 'single':
             case 'double':
@@ -1672,15 +1672,15 @@ class DB_Table extends DB_Table_Base
             }
         }
     }
-    
-    
+
+
     /**
      * Creates the table based on $this->col and $this->idx.
-     * 
+     *
      * @param string $flag The automatic table creation mode to pursue:
      * - 'safe' to create the table only if it does not exist
      * - 'drop' to drop any existing table with the same name and re-create it
-     * 
+     *
      * @return mixed Boolean true if the table was successfully created,
      *               false if there was no need to create the table, or
      *               a PEAR_Error if the attempted creation failed.
@@ -1688,9 +1688,9 @@ class DB_Table extends DB_Table_Base
      * @throws PEAR_Error if
      *     - DB_Table_Manager::tableExists() returns Error (bubbles up)
      *     - DB_Table_Manager::create() returns Error (bubbles up)
-     * 
+     *
      * @access public
-     * 
+     *
      * @see DB_Table_Manager::tableExists()
      * @see DB_Table_Manager::create()
      */
@@ -1700,7 +1700,7 @@ class DB_Table extends DB_Table_Base
 
         // are we OK to create the table?
         $ok = false;
-        
+
         // check the create-flag
         switch ($flag) {
 
@@ -1744,13 +1744,13 @@ class DB_Table extends DB_Table_Base
             $this->db, $this->table, $this->col, $this->idx
         );
     }
-    
-    
+
+
     /**
      * Alters the table to match schema declared in $this->col and $this->idx.
      *
      * If the table does not exist, create it instead.
-     * 
+     *
      * @return boolean true if altering is successful (PEAR_Error on failure)
      *
      * @throws PEAR_Error if
@@ -1767,7 +1767,7 @@ class DB_Table extends DB_Table_Base
     function alter()
     {
         $create = false;
-        
+
         // alter the table columns and indexes if the table exists
         $table_exists = DB_Table_Manager::tableExists($this->db,
                                                       $this->table);
@@ -1790,18 +1790,18 @@ class DB_Table extends DB_Table_Base
             $this->db, $this->table, $this->col, $this->idx
         );
     }
-    
-    
+
+
     /**
      * Verifies the table based on $this->col and $this->idx.
-     * 
+     *
      * @return boolean true if verification succees (PEAR_Error on failure).
      *
      * @throws PEAR_Error if
      *     DB_Table_Manager::verify() returns Error (bubbles up)
      *
      * @access public
-     * 
+     *
      * @see DB_Table_Manager::verify()
      */
     function verify()
@@ -1810,25 +1810,25 @@ class DB_Table extends DB_Table_Base
             $this->db, $this->table, $this->col, $this->idx
         );
     }
-    
-    
+
+
     /**
      * Checks if a value validates against the DB_Table data type for a
      * given column. This only checks that it matches the data type; it
      * does not do extended validation.
-     * 
+     *
      * @param array $val A value to check against the column's DB_Table
      * data type.
-     * 
+     *
      * @param array $col A column name from $this->col.
-     * 
+     *
      * @return boolean True if $val validates against data type, false if not
      *
      * @throws PEAR_Error if
      *     Invalid column type in $this->col (DB_TABLE_ERR_VALIDATE_TYPE)
      *
      * @access public
-     * 
+     *
      * @see DB_Table_Valid
      */
     function isValid($val, $col)
@@ -1844,15 +1844,15 @@ class DB_Table extends DB_Table_Base
                 return true;
             }
         }
-        
+
         // make sure we have the validation class
         include_once 'DB/Table/Valid.php';
-        
+
         // validate values per the column type.  we use sqlite
         // as the single authentic list of allowed column types,
         // regardless of the actual rdbms being used.
         $map = array_keys($GLOBALS['_DB_TABLE']['type']['sqlite']);
-        
+
         // is the column type on the map?
         if (! in_array($this->col[$col]['type'], $map)) {
             return $this->throwError(
@@ -1860,10 +1860,10 @@ class DB_Table extends DB_Table_Base
                 "'$col' ('{$this->col[$col]['type']}')"
             );
         }
-        
+
         // validate for the type
         switch ($this->col[$col]['type']) {
-        
+
         case 'char':
         case 'varchar':
             $result = DB_Table_Valid::isChar(
@@ -1871,7 +1871,7 @@ class DB_Table extends DB_Table_Base
                 $this->col[$col]['size']
             );
             break;
-        
+
         case 'decimal':
             $result = DB_Table_Valid::isDecimal(
                 $val,
@@ -1879,7 +1879,7 @@ class DB_Table extends DB_Table_Base
                 $this->col[$col]['scope']
             );
             break;
-            
+
         default:
             $result = call_user_func(
                 array(
@@ -1891,25 +1891,25 @@ class DB_Table extends DB_Table_Base
             break;
 
         }
-        
+
         // have we passed the check so far, and should we
         // also check for allowed values?
         if ($result && isset($this->col[$col]['qf_vals'])) {
             $keys = array_keys($this->col[$col]['qf_vals']);
-            
+
             $result = in_array(
                 $val,
                 array_keys($this->col[$col]['qf_vals'])
             );
         }
-        
+
         return $result;
     }
-    
-    
+
+
     /**
      * Is a specific column required to be set and non-null?
-     * 
+     *
      * @param mixed $column The column to check against.
      * @return boolean      True if required, false if not.
      * @access public
@@ -1923,10 +1923,10 @@ class DB_Table extends DB_Table_Base
             return false;
         }
     }
-    
-    
+
+
     /**
-     * 
+     *
      * Creates and returns a QuickForm object based on table columns.
      *
      * @param array $columns A sequential array of column names to use in
@@ -1936,27 +1936,27 @@ class DB_Table extends DB_Table_Base
      * of the columns as the names of the form elements.  If you pass
      * $array_name, the column names will become keys in an array named
      * for this parameter.
-     * 
+     *
      * @param array $args An associative array of optional arguments to
      * pass to the QuickForm object.  The keys are...
      *
      * 'formName' : String, name of the form; defaults to the name of this
      * table.
-     * 
+     *
      * 'method' : String, form method; defaults to 'post'.
-     * 
+     *
      * 'action' : String, form action; defaults to
      * $_SERVER['REQUEST_URI'].
-     * 
+     *
      * 'target' : String, form target target; defaults to '_self'
-     * 
+     *
      * 'attributes' : Associative array, extra attributes for <form>
      * tag; the key is the attribute name and the value is attribute
      * value.
-     * 
+     *
      * 'trackSubmit' : Boolean, whether to track if the form was
      * submitted by adding a special hidden field
-     * 
+     *
      * @param string $clientValidate By default, validation will match
      * the 'qf_client' value from the column definition.  However, if
      * you set $clientValidate to true or false, this will override the
@@ -1966,7 +1966,7 @@ class DB_Table extends DB_Table_Base
      * callbacks that will be applied to all form elements.
      *
      * @return object HTML_QuickForm
-     * 
+     *
      * @access public
      *
      * @see HTML_QuickForm
@@ -1981,30 +1981,30 @@ class DB_Table extends DB_Table_Base
             $clientValidate, $formFilters);
         return $form;
     }
-    
-    
+
+
     /**
      * Adds elements and rules to a pre-existing HTML_QuickForm object.
-     * 
-     * By default, the form will use the names of the columns as the names 
-     * of the form elements.  If you pass $array_name, the column names 
+     *
+     * By default, the form will use the names of the columns as the names
+     * of the form elements.  If you pass $array_name, the column names
      * will become keys in an array named for this parameter.
      *
      * @param object &$form      An HTML_QuickForm object.
-     * 
+     *
      * @param array $columns     A sequential array of column names to use in
      *                           the form; if null, uses all columns.
      *
      * @param string $array_name Name of array of column names
      *
      * @param clientValidate
-     * 
+     *
      * @return void
-     * 
+     *
      * @access public
-     * 
+     *
      * @see HTML_QuickForm
-     * 
+     *
      * @see DB_Table_QuickForm
      */
     function addFormElements(&$form, $columns = null, $array_name = null,
@@ -2013,20 +2013,20 @@ class DB_Table extends DB_Table_Base
         include_once 'DB/Table/QuickForm.php';
         $coldefs = $this->_getFormColDefs($columns);
         DB_Table_QuickForm::addElements($form, $coldefs, $array_name);
-        DB_Table_QuickForm::addRules($form, $coldefs, $array_name, 
+        DB_Table_QuickForm::addRules($form, $coldefs, $array_name,
            $clientValidate);
     }
 
 
     /**
-     * Adds static form elements like 'header', 'static', 'submit' or 'reset' 
+     * Adds static form elements like 'header', 'static', 'submit' or 'reset'
      * to a pre-existing HTML_QuickForm object. The form elements needs to be
      * defined in a property called $frm.
-     * 
+     *
      * @param object &$form An HTML_QuickForm object.
      * @return void
      * @access public
-     * 
+     *
      * @see HTML_QuickForm
      * @see DB_Table_QuickForm
      */
@@ -2038,22 +2038,22 @@ class DB_Table extends DB_Table_Base
 
 
     /**
-     * 
+     *
      * Creates and returns an array of QuickForm elements based on an
      * array of DB_Table column names.
-     * 
+     *
      * @param array $columns A sequential array of column names to use in
      * the form; if null, uses all columns.
-     * 
+     *
      * @param string $array_name By default, the form will use the names
      * of the columns as the names of the form elements.  If you pass
      * $array_name, the column names will become keys in an array named
      * for this parameter.
-     * 
+     *
      * @return array An array of HTML_QuickForm_Element objects.
-     * 
+     *
      * @access public
-     * 
+     *
      * @see HTML_QuickForm
      * @see DB_Table_QuickForm
      */
@@ -2064,24 +2064,24 @@ class DB_Table extends DB_Table_Base
         $group =& DB_Table_QuickForm::getGroup($coldefs, $array_name);
         return $group;
     }
-    
-    
+
+
     /**
      * Creates and returns a single QuickForm element based on a DB_Table
      * column name.
-     * 
+     *
      * @param string $column   A DB_Table column name.
      * @param string $elemname The name to use for the generated QuickForm
      *                         element.
-     * 
+     *
      * @return object HTML_QuickForm_Element
-     * 
+     *
      * @access public
-     * 
+     *
      * @see HTML_QuickForm
      * @see DB_Table_QuickForm
      */
-    
+
     function &getFormElement($column, $elemname)
     {
         include_once 'DB/Table/QuickForm.php';
@@ -2095,16 +2095,16 @@ class DB_Table extends DB_Table_Base
     /**
      * Creates and returns an array of QuickForm elements based on a DB_Table
      * column name.
-     * 
+     *
      * @author Ian Eure <ieure@php.net>
-     * 
+     *
      * @param array $cols        Array of DB_Table column names
      * @param string $array_name The name to use for the generated QuickForm
      *                           elements.
      * @return object HTML_QuickForm_Element
-     * 
+     *
      * @access public
-     * 
+     *
      * @see HTML_QuickForm
      * @see DB_Table_QuickForm
      */
@@ -2114,21 +2114,21 @@ class DB_Table extends DB_Table_Base
         $elements =& DB_Table_QuickForm::getElements($cols, $array_name);
         return $elements;
     }
-    
-    
+
+
     /**
      * Creates a column definition array suitable for DB_Table_QuickForm.
-     * 
+     *
      * @param string|array $column_set A string column name, a sequential
      * array of columns names, or an associative array where the key is a
      * column name and the value is the default value for the generated
      * form element.  If null, uses all columns for this class.
-     * 
+     *
      * @return array An array of column definitions suitable for passing
      *               to DB_Table_QuickForm.
      *
      * @access public
-     * 
+     *
      */
     function _getFormColDefs($column_set = null)
     {
@@ -2137,7 +2137,7 @@ class DB_Table extends DB_Table_Base
             // array.
             return $this->getColumns($column_set);
         }
-        
+
         // check to see if the keys are sequential integers.  if so,
         // the $column_set is just a list of columns.
         settype($column_set, 'array');
@@ -2149,24 +2149,24 @@ class DB_Table extends DB_Table_Base
                 break;
             }
         }
-        
+
         if ($all_integer) {
-        
+
             // the column_set is just a list of columns; get back the $this->col
             // array elements matching this list.
             $coldefs = $this->getColumns($column_set);
-            
+
         } else {
-            
+
             // the columns_set is an associative array where the key is a
             // column name and the value is the form element value.
             $coldefs = $this->getColumns($keys);
             foreach ($coldefs as $key => $val) {
                 $coldefs[$key]['qf_setvalue'] = $column_set[$key];
             }
-            
+
         }
-        
+
         return $coldefs;
     }
 

--- a/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Database.php
+++ b/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Database.php
@@ -142,13 +142,13 @@ define('DB_TABLE_DATABASE_ERR_NO_COL_TBL', -224);
 define('DB_TABLE_DATABASE_ERR_SQL_UNDEF', -225);
 
 /**
- * Error in a buildSQL or select* method for a key of $this->sql that is 
+ * Error in a buildSQL or select* method for a key of $this->sql that is
  * not a string
  */
 define('DB_TABLE_DATABASE_ERR_SQL_NOT_STRING', -226);
 
 /**
- * Error in buildFilter due to invalid match type 
+ * Error in buildFilter due to invalid match type
  */
 define('DB_TABLE_DATABASE_ERR_MATCH_TYPE', -227);
 
@@ -203,7 +203,7 @@ define('DB_TABLE_DATABASE_ERR_COL_NOT_UNIQUE', -236);
 define('DB_TABLE_DATABASE_ERR_AMBIG_JOIN', -237);
 
 /**
- * Error in autoJoin for failed construction of join 
+ * Error in autoJoin for failed construction of join
  */
 define('DB_TABLE_DATABASE_ERR_FAIL_JOIN', -238);
 
@@ -234,11 +234,11 @@ require_once 'DB/Table.php';
  */
 require_once 'PEAR.php';
 
-/** 
+/**
  * US-English default error messages. If you want to internationalize, you can
- * set the translated messages via $GLOBALS['_DB_TABLE_DATABASE']['error']. 
+ * set the translated messages via $GLOBALS['_DB_TABLE_DATABASE']['error'].
  * You can also use DB_Table_Database::setErrorMessage(). Examples:
- * 
+ *
  * <code>
  * (1) $GLOBALS['_DB_TABLE_DATABASE']['error'] = array(
  *                                           DB_TABLE_DATABASE_ERR_.. => '...',
@@ -255,7 +255,7 @@ require_once 'PEAR.php';
  *     $obj->setErrorMessage(array(DB_TABLE_DATABASE_ERR_.. => '...');
  *                                 DB_TABLE_DATABASE_ERR_.. => '...');
  * </code>
- * 
+ *
  * For errors that can occur with-in the constructor call (i.e. e.g. creating
  * or altering the database table), only the code from examples (1) to (3)
  * will alter the default error messages early enough. For errors that can
@@ -359,7 +359,7 @@ foreach ($GLOBALS['_DB_TABLE_DATABASE']['default_error'] as $code => $message) {
  *
  * DB_Table_Database is an abstraction class for a relational database.
  * It is a layer built on top of DB_Table, in which each table in a
- * database is represented as an instance of DB_Table. It provides: 
+ * database is represented as an instance of DB_Table. It provides:
  *
  *   - an object-oriented representation of the database schema
  *   - automated construction of SQL commands for simple joins
@@ -367,8 +367,8 @@ foreach ($GLOBALS['_DB_TABLE_DATABASE']['default_error'] as $code => $message) {
  *     to that of DB_Table, with optional emulation of standard SQL
  *     foreign key integrity checks and referential triggered actions
  *     such as cascading deletes.
- *   - Serialization and unserialization of the database schema via 
- *     either php serialization or XML, using the MDB2 XML schema. 
+ *   - Serialization and unserialization of the database schema via
+ *     either php serialization or XML, using the MDB2 XML schema.
  *
  * @category Database
  * @package  DB_Table
@@ -403,8 +403,8 @@ class DB_Table_Database extends DB_Table_Base
     /**
      * Array in which keys are table names, values are DB_Table subclass names.
      *
-     * See the getTableSubclass() method docblock for further details. 
-     * 
+     * See the getTableSubclass() method docblock for further details.
+     *
      * @var    array
      * @access private
      */
@@ -413,8 +413,8 @@ class DB_Table_Database extends DB_Table_Base
     /**
      * Path to directory containing DB_Table subclass declaration files
      *
-     * See the setTableSubclassPath() method docblock for further details. 
-     * 
+     * See the setTableSubclassPath() method docblock for further details.
+     *
      * @var    string
      * @access private
      */
@@ -424,9 +424,9 @@ class DB_Table_Database extends DB_Table_Base
      * Array in which keys are table names, values are primary keys.
      *
      * Each primary key value may be a column name string, a sequential array of
-     * column name strings, or null. 
+     * column name strings, or null.
      *
-     * See the getPrimaryKey() method docblock for details. 
+     * See the getPrimaryKey() method docblock for details.
      *
      * @var    array
      * @access private
@@ -437,8 +437,8 @@ class DB_Table_Database extends DB_Table_Base
      * Associative array that maps column names keys to table names.
      *
      * Each key is the name string of a column in the database. Each value
-     * is a numerical array containing the names of all tables that contain 
-     * a column with that name. 
+     * is a numerical array containing the names of all tables that contain
+     * a column with that name.
      *
      * See the getCol() method docblock for details.
      *
@@ -451,10 +451,10 @@ class DB_Table_Database extends DB_Table_Base
      * Associative array that maps names of foreign key columns to table names
      *
      * Each key is the name string of a foreign key column. Each value is a
-     * sequential array containing the names of all tables that contain a 
-     * foreign key column with that name. 
+     * sequential array containing the names of all tables that contain a
+     * foreign key column with that name.
      *
-     * See the getForeignCol() method docblock for further details. 
+     * See the getForeignCol() method docblock for further details.
      *
      * @var    array
      * @access private
@@ -462,14 +462,14 @@ class DB_Table_Database extends DB_Table_Base
     var $_foreign_col = array();
 
     /**
-     * Two-dimensional associative array of foreign key references. 
+     * Two-dimensional associative array of foreign key references.
      *
      * Keys are pairs of table names (referencing table first, referenced
-     * table second). Each value is an array containing information about 
-     * the referencing and referenced keys, and about any referentially 
-     * triggered actions (e.g., cascading delete). 
+     * table second). Each value is an array containing information about
+     * the referencing and referenced keys, and about any referentially
+     * triggered actions (e.g., cascading delete).
      *
-     * See the getRef() docblock for further details. 
+     * See the getRef() docblock for further details.
      *
      * @var    array
      * @access private
@@ -477,29 +477,29 @@ class DB_Table_Database extends DB_Table_Base
     var $_ref = array();
 
     /**
-     * Array in which each key is the names of a referenced tables, each value 
+     * Array in which each key is the names of a referenced tables, each value
      * an sequential array containing names of referencing tables.
      *
-     * See the docblock for the getRefTo() method for further discussion. 
-     * 
+     * See the docblock for the getRefTo() method for further discussion.
+     *
      * @var    array
      * @access private
      */
     var $_ref_to = array();
 
     /**
-     * Two-dimensional associative array of linking tables. 
+     * Two-dimensional associative array of linking tables.
      *
      * Two-dimensional associative array in which pairs of keys are names
-     * of pairs of tables that are linked by one or more linking/association 
+     * of pairs of tables that are linked by one or more linking/association
      * table. Each value is an array containing the names of all table that
-     * link the tables specified by the pair of keys. A linking table is a 
+     * link the tables specified by the pair of keys. A linking table is a
      * table that creates a many-to-many relationship between two linked
      * tables, via foreign key references from the linking table to the two
-     * linked tables. The $_link property is used by the autoJoin() method 
-     * to join tables that are related only through such a linking table. 
-     * 
-     * See the getLink() method docblock for further details. 
+     * linked tables. The $_link property is used by the autoJoin() method
+     * to join tables that are related only through such a linking table.
+     *
+     * See the getLink() method docblock for further details.
      *
      * @var    array
      * @access private
@@ -508,25 +508,25 @@ class DB_Table_Database extends DB_Table_Base
 
     /**
      * If the column keys in associative array return sets are fixed case
-     * (all upper or lower case) this property should be set true. 
+     * (all upper or lower case) this property should be set true.
      *
-     * The column keys in rows of associative array return sets may either 
+     * The column keys in rows of associative array return sets may either
      * preserve capitalization of the column names or they may be fixed case,
      * depending on the options set in the backend (DB/MDB2) and on phptype.
-     * If these column names are returned with a fixed case (either upper 
+     * If these column names are returned with a fixed case (either upper
      * or lower), $fix_case must be set true in order for php emulation of
      * ON DELETE and ON UPDATE actions to work correctly. Otherwise, the
      * $fix_case property should be false (the default).
      *
      * The choice between mixed or fixed case column keys may be made by using
      * using the setFixCase() method, which resets both the behavior of the
-     * backend and the $fix_case property. It may also be changed by using the 
-     * setOption() method of the DB or MDB2 backend object to directly set the 
-     * DB_PORTABILITY_LOWERCASE or MDB2_PORTABILITY_FIX_CASE bits of the 
+     * backend and the $fix_case property. It may also be changed by using the
+     * setOption() method of the DB or MDB2 backend object to directly set the
+     * DB_PORTABILITY_LOWERCASE or MDB2_PORTABILITY_FIX_CASE bits of the
      * DB/MDB2 'portability' option.
      *
-     * By default, DB returns mixed case and MDB2 returns lower case. 
-     * 
+     * By default, DB returns mixed case and MDB2 returns lower case.
+     *
      * @see DB_Table_Database::setFixCase()
      * @see DB::setOption()
      * @see MDB2::setOption()
@@ -575,14 +575,14 @@ class DB_Table_Database extends DB_Table_Base
      * If an error is encountered during instantiation, the error
      * message is stored in the $this->error property of the resulting
      * object. See $error property docblock for a discussion of error
-     * handling. 
-     * 
+     * handling.
+     *
      * @param  object &$db   DB/MDB2 database connection object
      * @param  string $name the database name
      * @return object DB_Table_Database
      * @access public
      */
-    function DB_Table_Database(&$db, $name)
+    function __construct(&$db, $name)
     {
         // Is $db an DB/MDB2 object or null?
         if (is_a($db, 'db_common')) {
@@ -659,7 +659,7 @@ class DB_Table_Database extends DB_Table_Base
             $this->_act_on_delete = false;
         }
     }
-    
+
     /**
      * Turns on (or off) automatic php emulation of on update actions
      *
@@ -675,7 +675,7 @@ class DB_Table_Database extends DB_Table_Base
             $this->_act_on_update = false;
         }
     }
-    
+
     /**
      * Turns on (or off) validation of foreign key values on insert and update
      *
@@ -695,10 +695,10 @@ class DB_Table_Database extends DB_Table_Base
     /**
      * Sets backend option such that column keys in associative array return
      * sets are converted to fixed case, if true, or mixed case, if false.
-     * 
+     *
      * Sets the DB/MDB2 'portability' option, and sets $this->fix_case = $flag.
      */
-    function setFixCase($flag = false) 
+    function setFixCase($flag = false)
     {
         $flag = (bool) $flag;
         $option = $this->db->getOption('portability');
@@ -712,18 +712,18 @@ class DB_Table_Database extends DB_Table_Base
             if (!$flag) {
                 $option = $option ^ MDB2_PORTABILITY_FIX_CASE;
             }
-        } 
+        }
         $this->db->setOption('portability', $option);
         $this->fix_case = $flag;
     }
-    
+
     /**
      * Return reference to $this->db DB/MDB2 object
      *
      * @return object reference to DB/MDB2 object
      * @access public
      */
-    function &getDBInstance() 
+    function &getDBInstance()
     {
         return $this->db;
     }
@@ -737,17 +737,17 @@ class DB_Table_Database extends DB_Table_Base
      *
      * Returns PEAR_Error with the following DB_TABLE_DATABASE_ERR* codes
      * if:
-     *    - $name is not a string ( _TBL_NOT_STRING )
-     *    - $name is not valid table name ( _NO_TBL )
-     * 
+     *    - $name is not a string (_TBL_NOT_STRING )
+     *    - $name is not valid table name (_NO_TBL )
+     *
      * The $_table property is an associative array in which keys are table
-     * name strings and values are references to DB_Table objects. Each of 
+     * name strings and values are references to DB_Table objects. Each of
      * the referenced objects represents one table in the database.
      *
      * @return mixed $_table property, one element of $_table, or Error
      * @access public
      */
-    function getTable($name = null) 
+    function getTable($name = null)
     {
         if (is_null($name)) {
             return $this->_table;
@@ -774,19 +774,19 @@ class DB_Table_Database extends DB_Table_Base
      *
      * Returns PEAR_Error with the following DB_TABLE_DATABASE_* error
      * codes if:
-     *    - $name is not a string ( _TBL_NOT_STRING )
-     *    - $name is not valid table name ( _NO_TBL )
-     * 
+     *    - $name is not a string (_TBL_NOT_STRING )
+     *    - $name is not valid table name (_NO_TBL )
+     *
      * The $_primary_key property is an associative array in which each key
      * a table name, and each value is the primary key of that table. Each
-     * primary key value may be a column name string, a sequential array of 
+     * primary key value may be a column name string, a sequential array of
      * column name strings (for a multi-column key), or null (if no primary
      * key has been declared).
      *
      * @return mixed $primary_key array or $this->_primary_key[$name]
      * @access public
      */
-    function getPrimaryKey($name = null) 
+    function getPrimaryKey($name = null)
     {
         if (is_null($name)) {
             return $this->_primary_key;
@@ -813,33 +813,33 @@ class DB_Table_Database extends DB_Table_Base
      *
      * Returns PEAR_Error with the following DB_TABLE_DATABASE_* error
      * codes if:
-     *    - $name is not a string ( _TBL_NOT_STRING )
-     *    - $name is not valid table name ( _NO_TBL )
+     *    - $name is not a string (_TBL_NOT_STRING )
+     *    - $name is not valid table name (_NO_TBL )
      *
      * The $_table_subclass property is an associative array in which each key
-     * is a table name string, and each value is the name of the corresponding 
-     * subclass of DB_Table. The value is null if the table is an instance of 
-     * DB_Table itself. 
+     * is a table name string, and each value is the name of the corresponding
+     * subclass of DB_Table. The value is null if the table is an instance of
+     * DB_Table itself.
      *
-     * Subclass names are set within the addTable method by applying the 
-     * built in get_class() function to a DB_Table object. The class names 
+     * Subclass names are set within the addTable method by applying the
+     * built in get_class() function to a DB_Table object. The class names
      * returned by get_class() are stored unmodified. In PHP 4, get_class
-     * converts all class names to lower case. In PHP 5, it preserves the 
-     * capitalization of the name used in the class definition. 
+     * converts all class names to lower case. In PHP 5, it preserves the
+     * capitalization of the name used in the class definition.
      *
      * In the __wakeup() method, for each table $table_name for which
      * $subclass = $this->_table_subclass[$table_name] is not null, but
      * class $subclass is not defined, the method attempts to include a
-     * file named "$subclass.php" in directory $this->table_subclass_path. 
-     * For autoloading to work properly, the base name of each subclass 
+     * file named "$subclass.php" in directory $this->table_subclass_path.
+     * For autoloading to work properly, the base name of each subclass
      * definition file (excluding the .php extension) should thus be a
-     * lower case version of the class name in PHP 4 or identical to the 
-     * class name in PHP 5. 
-     * 
+     * lower case version of the class name in PHP 4 or identical to the
+     * class name in PHP 5.
+     *
      * @return mixed $_table_subclass array or $this->_table_subclass[$name]
      * @access public
      */
-    function getTableSubclass($name = null) 
+    function getTableSubclass($name = null)
     {
         if (is_null($name)) {
             return $this->_table_subclass;
@@ -866,12 +866,12 @@ class DB_Table_Database extends DB_Table_Base
      *
      * Returns a PEAR_Error with the following DB_TABLE_DATABASE_* error
      * codes if:
-     *    - $column_name is not a string ( _COL_NOT_STRING )
-     *    - $column_name is not valid column name ( _NO_COL )
+     *    - $column_name is not a string (_COL_NOT_STRING )
+     *    - $column_name is not valid column name (_NO_COL )
      *
      * The $_col property is an associative array in which each key is the
-     * name of a column in the database, and each value is a numerical array 
-     * containing the names of all tables that contain a column with that 
+     * name of a column in the database, and each value is a numerical array
+     * containing the names of all tables that contain a column with that
      * name.
      *
      * @var    array
@@ -879,7 +879,7 @@ class DB_Table_Database extends DB_Table_Base
      * @return mixed $this->_col property array or $this->_col[$column_name]
      * @access public
      */
-    function getCol($column_name = null) 
+    function getCol($column_name = null)
     {
         if (is_null($column_name)) {
             return $this->_col;
@@ -902,28 +902,28 @@ class DB_Table_Database extends DB_Table_Base
      * Returns all or part of the $_foreign_col property array
      *
      * If $column_name is null, return $this->_foreign_col property array
-     * If $column_name is valid, return $this->_foreign_col[$column_name] 
+     * If $column_name is valid, return $this->_foreign_col[$column_name]
      *
      * Returns a PEAR_Error with the following DB_TABLE_DATABASE_* error
      * codes if:
-     *    - $column_name is not a string ( _COL_NOT_STRING )
-     *    - $column_name is not valid foreign column name ( _NO_FOREIGN_COL )
+     *    - $column_name is not a string (_COL_NOT_STRING )
+     *    - $column_name is not valid foreign column name (_NO_FOREIGN_COL )
      *
-     * The $_foreign_col property is an associative array in which each 
+     * The $_foreign_col property is an associative array in which each
      * key is the name string of a foreign key column, and each value is a
-     * sequential array containing the names of all tables that contain a 
-     * foreign key column with that name. 
+     * sequential array containing the names of all tables that contain a
+     * foreign key column with that name.
      *
-     * If a column $column in a referencing table $ftable is part of the 
+     * If a column $column in a referencing table $ftable is part of the
      * foreign key for references to two or more different referenced tables
-     * tables, the name $ftable will also appear multiple times in the array 
+     * tables, the name $ftable will also appear multiple times in the array
      * $this->_foreign_col[$column].
      *
      * @param  string column name string for foreign key column
      * @return array  $_foreign_col property array
      * @access public
      */
-    function getForeignCol($column_name = null) 
+    function getForeignCol($column_name = null)
     {
         if (is_null($column_name)) {
             return $this->_foreign_col;
@@ -949,35 +949,35 @@ class DB_Table_Database extends DB_Table_Base
      * Returns $this->_ref[$table1] subarray if only $table2 is null.
      * Returns $this->_ref[$table1][$table2] if both parameters are present.
      *
-     * Returns null if $table1 is a table that references no others, or 
-     * if $table1 and $table2 are both valid table names, but there is no 
+     * Returns null if $table1 is a table that references no others, or
+     * if $table1 and $table2 are both valid table names, but there is no
      * reference from $table1 to $table2.
-     * 
+     *
      * Returns a PEAR_Error with the following DB_TABLE_DATABASE_* error
      * codes if:
-     *    - $table1 or $table2 is not a string ( _TBL_NOT_STRING )
-     *    - $table1 or $table2 is not a valid table name ( _NO_TBL )
+     *    - $table1 or $table2 is not a string (_TBL_NOT_STRING )
+     *    - $table1 or $table2 is not a valid table name (_NO_TBL )
      *
      * The $_ref property is a two-dimensional associative array in which
-     * the keys are pairs of table names, each value is an array containing 
+     * the keys are pairs of table names, each value is an array containing
      * information about referenced and referencing keys, and referentially
-     * triggered actions (if any).  An element of the $_ref array is of the 
-     * form $ref[$ftable][$rtable] = $reference, where $ftable is the name 
-     * of a referencing (or foreign key) table and $rtable is the name of 
-     * a corresponding referenced table. The value $reference is an array 
+     * triggered actions (if any).  An element of the $_ref array is of the
+     * form $ref[$ftable][$rtable] = $reference, where $ftable is the name
+     * of a referencing (or foreign key) table and $rtable is the name of
+     * a corresponding referenced table. The value $reference is an array
      * $reference = array($fkey, $rkey, $on_delete, $on_update) in which
-     * $fkey and $rkey are the foreign (or referencing) and referenced 
+     * $fkey and $rkey are the foreign (or referencing) and referenced
      * keys, respectively: Foreign key $fkey of table $ftable references
-     * key $rkey of table $rtable. The values of $fkey and $rkey must either 
-     * both be valid column name strings for columns of the same type, or 
-     * they may both be sequential arrays of column name names, with equal 
-     * numbers of columns of corresponding types, for multi-column keys. The 
-     * $on_delete and $on_update values may be either null or string values 
-     * that indicate actions to be taken upon deletion or updating of a 
+     * key $rkey of table $rtable. The values of $fkey and $rkey must either
+     * both be valid column name strings for columns of the same type, or
+     * they may both be sequential arrays of column name names, with equal
+     * numbers of columns of corresponding types, for multi-column keys. The
+     * $on_delete and $on_update values may be either null or string values
+     * that indicate actions to be taken upon deletion or updating of a
      * referenced row (e.g., cascading deletes). A null value of $on_delete
-     * or $on_update indicates that no referentially triggered action will 
+     * or $on_update indicates that no referentially triggered action will
      * be taken. See addRef() for further details about allowed values of
-     * these action strings. 
+     * these action strings.
      *
      * @var    array
      * @param  string $table1 name of referencing table
@@ -985,7 +985,7 @@ class DB_Table_Database extends DB_Table_Base
      * @return mixed $ref property array, sub-array, or value
      * @access public
      */
-    function getRef($table1 = null, $table2 = null) 
+    function getRef($table1 = null, $table2 = null)
     {
         if (is_null($table1)) {
             return $this->_ref;
@@ -1039,17 +1039,17 @@ class DB_Table_Database extends DB_Table_Base
      *
      * Returns a PEAR_Error with the following DB_TABLE_DATABASE_* error
      * codes if:
-     *    - $table_name is not a string ( _TBL_NOT_STRING )
-     *    - $table_name is not a valid table name ( _NO_TBL )
+     *    - $table_name is not a string (_TBL_NOT_STRING )
+     *    - $table_name is not a valid table name (_NO_TBL )
      *
      * The $_ref_to property is an associative array in which each key
      * is the name of a referenced table, and each value is a sequential
      * array containing the names of all tables that contain foreign keys
      * that reference that table. Each element is thus of the form
      * $_ref_to[$rtable] = array($ftable1, $ftable2,...), where
-     * $ftable1, $ftable2, ... are the names of tables that reference 
+     * $ftable1, $ftable2, ... are the names of tables that reference
      * the table named $rtable.
-     * 
+     *
      * @param string $table_name name of table
      * @return mixed $_ref_to property array or subarray
      * @access public
@@ -1086,38 +1086,38 @@ class DB_Table_Database extends DB_Table_Base
      * Returns $this->_link[$table1] subarray if only $table2 is null.
      * Returns $this->_link[$table1][$table2] if both parameters are present.
      *
-     * Returns null if $table1 is a valid table with links to no others, or 
-     * if $table1 and $table2 are both valid table names but there is no 
+     * Returns null if $table1 is a valid table with links to no others, or
+     * if $table1 and $table2 are both valid table names but there is no
      * link between them.
-     * 
+     *
      * Returns a PEAR_Error with the following DB_TABLE_DATABASE_* error
      * codes if $table1 or $table2 is not null and:
-     *    - $table1 or $table2 is not a string ( _TBL_NOT_STRING )
-     *    - $table1 or $table2 is not a valid table name ( _NO_TBL )
+     *    - $table1 or $table2 is not a string (_TBL_NOT_STRING )
+     *    - $table1 or $table2 is not a valid table name (_NO_TBL )
      *
-     * The $_link property is a two-dimensional associative array with 
-     * elements of the form $this->_link[$table1][$table2] = array($link1, ...), 
-     * in which the value is an array containing the names of all tables 
+     * The $_link property is a two-dimensional associative array with
+     * elements of the form $this->_link[$table1][$table2] = array($link1, ...),
+     * in which the value is an array containing the names of all tables
      * that `link' tables named $table1 and $table2, and thereby create a
-     * many-to-many relationship between these two tables. 
+     * many-to-many relationship between these two tables.
      *
      * The $_link property is used in the autoJoin method to join tables
      * that are related by a many-to-many relationship via a linking table,
      * rather than via a direct foreign key reference. A table that is
-     * declared to be linking table for tables $table1 and $table2 must 
-     * contain foreign keys that reference both of these tables. 
+     * declared to be linking table for tables $table1 and $table2 must
+     * contain foreign keys that reference both of these tables.
      *
      * Each binary link in a database is listed twice in $_link, in
      * $_link[$table1][$table2] and in $_link[$table2][$table1]. If a
      * linking table contains foreign key references to N tables, with
      * N > 2, each of the resulting binary links is listed separately.
-     * For example, a table with references to 3 tables A, B, and C can 
-     * create three binary links (AB, AC, and BC) and six entries in the 
+     * For example, a table with references to 3 tables A, B, and C can
+     * create three binary links (AB, AC, and BC) and six entries in the
      * link property array (i.e., in $_link[A][B], $_link[B][A], ... ).
      *
-     * Linking tables may be added to the $_link property by using the 
-     * addLink method or deleted using the delLink method. Alternatively, 
-     * all possible linking tables can be identified and added to the 
+     * Linking tables may be added to the $_link property by using the
+     * addLink method or deleted using the delLink method. Alternatively,
+     * all possible linking tables can be identified and added to the
      * $_link array at once by the addAllLinks() method.
      *
      * @var    array
@@ -1126,7 +1126,7 @@ class DB_Table_Database extends DB_Table_Base
      * @return mixed $_link property array, sub-array, or value
      * @access public
      */
-    function getLink($table1 = null, $table2 = null) 
+    function getLink($table1 = null, $table2 = null)
     {
         if (is_null($table1)) {
             return $this->_link;
@@ -1175,13 +1175,13 @@ class DB_Table_Database extends DB_Table_Base
      * Sets the path to a the directory containing DB_Table subclass definitions.
      *
      * This method sets the $_table_subclass_path string property. The value of
-     * this property is the path to the directory containing DB_Table subclass 
-     * definitions, without a trailing directory separator. 
-     *  
-     * This path may be used by the __wakeup(), if necessary, in an attempt to 
-     * autoload class definitions when unserializing a DB_Table_Database object 
+     * this property is the path to the directory containing DB_Table subclass
+     * definitions, without a trailing directory separator.
+     *
+     * This path may be used by the __wakeup(), if necessary, in an attempt to
+     * autoload class definitions when unserializing a DB_Table_Database object
      * and its child DB_Table objects. If a DB_Table subclass named $subclass_name
-     * has not been defined when it is needed, within DB_Table_Database::__wakeup(), 
+     * has not been defined when it is needed, within DB_Table_Database::__wakeup(),
      * to unserialize an instance of this class, the __wakeup() method attempts
      * to include a class definition file from this directory, as follows:
      * <code>
@@ -1189,14 +1189,14 @@ class DB_Table_Database extends DB_Table_Base
      *     require_once $dir . '/' . $subclass . '.php';
      * </code>
      * See the getTableSubclass() docblock for a discusion of capitalization
-     * conventions in PHP 4 and 5 for subclass file names. 
-     * 
+     * conventions in PHP 4 and 5 for subclass file names.
+     *
      * @param string $path path to directory containing class definitions
      * @return void
      * @access public
      */
     function setTableSubclassPath($path) {
-        $this->_table_subclass_path = $path; 
+        $this->_table_subclass_path = $path;
     }
 
     /**
@@ -1205,17 +1205,17 @@ class DB_Table_Database extends DB_Table_Base
      * Creates references between $this DB_Table_Database object and
      * the child DB_Table object, by adding a reference to $table_obj
      * to the $this->_table array, and setting $table_obj->database =
-     * $this. 
+     * $this.
      *
      * Adds the primary key to $this->_primary_key array. The relevant
-     * element of $this->_primary_key is set to null if no primary key 
+     * element of $this->_primary_key is set to null if no primary key
      * index is declared. Returns an error if more than one primary key
      * is declared.
      *
      * Returns true on success, and PEAR error on failure. Returns the
      * following DB_TABLE_DATABASE_ERR_* error codes if:
-     *    - $table_obj is not a DB_Table ( _DBTABLE_OBJECT )
-     *    - more than one primary key is defined  ( _ERR_MULT_PKEY )
+     *    - $table_obj is not a DB_Table (_DBTABLE_OBJECT )
+     *    - more than one primary key is defined  (_ERR_MULT_PKEY )
      *
      * @param  object &$table_obj the DB_Table object (reference)
      * @return boolean true on success (PEAR_Error on failure)
@@ -1223,7 +1223,7 @@ class DB_Table_Database extends DB_Table_Base
      */
     function addTable(&$table_obj)
     {
-        // Check that $table_obj is a DB_Table object 
+        // Check that $table_obj is a DB_Table object
         // Identify subclass name, if any
         if (is_subclass_of($table_obj, 'DB_Table')) {
             $subclass = get_class($table_obj);
@@ -1236,8 +1236,8 @@ class DB_Table_Database extends DB_Table_Base
 
         // Identify table name and table object (sub)class name
         $table = $table_obj->table;
-        
-        // Set $this->_primary_key[$table] 
+
+        // Set $this->_primary_key[$table]
         $this->_primary_key[$table] = null;
         foreach ($table_obj->idx as $idx_name => $idx_def) {
             if ($idx_def['type'] == 'primary') {
@@ -1254,7 +1254,7 @@ class DB_Table_Database extends DB_Table_Base
 
         // Add references between $this parent and child table object
         $this->_table[$table] =& $table_obj;
-        $table_obj->setDatabaseInstance($this); 
+        $table_obj->setDatabaseInstance($this);
 
         // Add subclass name (if any) to $this->_table_subclass
         $this->_table_subclass[$table] = $subclass;
@@ -1278,17 +1278,17 @@ class DB_Table_Database extends DB_Table_Base
     /**
      * Deletes a table from $this database object.
      *
-     * Removes all dependencies on $table from the database model. The table 
+     * Removes all dependencies on $table from the database model. The table
      * is removed from $_table and $_primary_key properties. Its columns are
      * removed from the $_col and $_foreign_col properties. References to
      * and from the table are removed from the $_ref, $_ref_to, and $_link
      * properties. Referencing columns are removed from $_foreign_col.
-     * 
+     *
      * @param  string $table name of table to be deleted
      * @return void
      * @access public
      */
-    function deleteTable($table) 
+    function deleteTable($table)
     {
         if (isset($this->_table[$table])) {
             $table_obj =& $this->_table[$table];
@@ -1327,17 +1327,17 @@ class DB_Table_Database extends DB_Table_Base
         }
 
         // Remove all references involving the deleted table.
-        // Corresponding links are removed from $this->_link by deleteRef 
+        // Corresponding links are removed from $this->_link by deleteRef
         // Referencing columns are removed from $this->_foreign_col by deleteRef
         foreach ($this->_ref as $ftable => $referenced) {
             foreach ($referenced as $rtable => $ref) {
                 if ($ftable == $table || $rtable == $table) {
                     $this->deleteRef($ftable, $rtable);
-                } 
-            } 
+                }
+            }
         }
 
-        // Remove table from $this->_table and $this->_primary_key 
+        // Remove table from $this->_table and $this->_primary_key
         unset($this->_table[$table]);
         unset($this->_primary_key[$table]);
     }
@@ -1347,41 +1347,41 @@ class DB_Table_Database extends DB_Table_Base
      *
      * Adds a reference from foreign key $fkey of table $ftable to
      * referenced key $rkey of table named $rtable to the $this->_ref
-     * property. The values of $fkey and $rkey (if not null) may either 
-     * both be column name strings (for single column keys) or they 
-     * may both be numerically indexed arrays of corresponding column 
-     * names (for multi-column keys). If $rkey is null (the default), 
-     * the referenced key taken to be the primary key of $rtable, if 
+     * property. The values of $fkey and $rkey (if not null) may either
+     * both be column name strings (for single column keys) or they
+     * may both be numerically indexed arrays of corresponding column
+     * names (for multi-column keys). If $rkey is null (the default),
+     * the referenced key taken to be the primary key of $rtable, if
      * any.
      *
-     * The $on_delete and $on_update parameters may be either be null, 
-     * or may have string values 'restrict', 'cascade', 'set null', or 
-     * 'set default' that indicate referentially triggered actions to be 
-     * taken deletion or updating of referenced row in $rtable. Each of 
-     * these actions corresponds to a standard SQL action (e.g., cascading 
-     * delete) that may be taken upon referencing rows of table $ftable 
-     * when a referenced row of $rtable is deleted or updated.  A PHP 
+     * The $on_delete and $on_update parameters may be either be null,
+     * or may have string values 'restrict', 'cascade', 'set null', or
+     * 'set default' that indicate referentially triggered actions to be
+     * taken deletion or updating of referenced row in $rtable. Each of
+     * these actions corresponds to a standard SQL action (e.g., cascading
+     * delete) that may be taken upon referencing rows of table $ftable
+     * when a referenced row of $rtable is deleted or updated.  A PHP
      * null value for either parameter (the default) signifies that no
-     * such action will be taken upon deletion or updating. 
+     * such action will be taken upon deletion or updating.
      *
      * There may no more than one reference from a table to another, though
-     * reference may contain multiple columns. 
+     * reference may contain multiple columns.
      *
      * Returns true on success, and PEAR error on failure. Returns the
      * following DB_TABLE_DATABASE_ERR_* error codes if:
-     *   - $ftable does not exist ( _NO_FTABLE )
-     *   - $rtable does not exist ( _NO_RTABLE )
-     *   - $rkey is null and $rtable has no primary key ( _NO_PKEY )
-     *   - $fkey is neither a string nor an array ( _FKEY )
-     *   - $rkey is not a string, $fkey is a string ( _RKEY_NOT_STRING )
-     *   - $rkey is not an array, $fkey is an array ( _RKEY_NOT_ARRAY )
-     *   - A column of $fkey does not exist ( _NO_FCOL )
-     *   - A column of $rkey does not exist ( _NO_RCOL )
-     *   - A column of $fkey and $rkey have different types ( _REF_TYPE )
-     *   - A reference from $ftable to $rtable already exists ( _MULT_REF )
-     * 
+     *   - $ftable does not exist (_NO_FTABLE )
+     *   - $rtable does not exist (_NO_RTABLE )
+     *   - $rkey is null and $rtable has no primary key (_NO_PKEY )
+     *   - $fkey is neither a string nor an array (_FKEY )
+     *   - $rkey is not a string, $fkey is a string (_RKEY_NOT_STRING )
+     *   - $rkey is not an array, $fkey is an array (_RKEY_NOT_ARRAY )
+     *   - A column of $fkey does not exist (_NO_FCOL )
+     *   - A column of $rkey does not exist (_NO_RCOL )
+     *   - A column of $fkey and $rkey have different types (_REF_TYPE )
+     *   - A reference from $ftable to $rtable already exists (_MULT_REF )
+     *
      * @param  string  $ftable    name of foreign/referencing table
-     * @param  mixed   $fkey      foreign key in referencing table 
+     * @param  mixed   $fkey      foreign key in referencing table
      * @param  string  $rtable    name of referenced table
      * @param  mixed   $rkey      referenced key in referenced table
      * @param  string  $on_delete action upon delete of a referenced row.
@@ -1485,7 +1485,7 @@ class DB_Table_Database extends DB_Table_Base
         }
 
         // Check validity of on_delete and on_update actions
-        $valid_actions = 
+        $valid_actions =
                array(null, 'cascade', 'set null', 'set default', 'restrict');
         if (!in_array($on_delete, $valid_actions)) {
             return $this->throwError(
@@ -1500,9 +1500,9 @@ class DB_Table_Database extends DB_Table_Base
 
         // Add reference to $this->_ref;
         $ref = array(
-               'fkey' => $fkey, 
+               'fkey' => $fkey,
                'rkey' => $rkey,
-               'on_delete' => $on_delete, 
+               'on_delete' => $on_delete,
                'on_update' => $on_update);
         if (!isset($this->_ref[$ftable])) {
             $this->_ref[$ftable] = array();
@@ -1541,24 +1541,24 @@ class DB_Table_Database extends DB_Table_Base
         return true;
     }
 
- 
+
     /**
      * Deletes one reference from database model
      *
      * Removes reference from referencing (foreign key) table named
      * $ftable to referenced table named $rtable. Unsets relevant elements
      * of the $ref, $_ref_to, and $_link property arrays, and removes the
-     * foreign key columns of $ftable from the $_foreign_col property. 
+     * foreign key columns of $ftable from the $_foreign_col property.
      *
-     * Does nothing, silently, if no such reference exists, i.e., if 
+     * Does nothing, silently, if no such reference exists, i.e., if
      * $this->_ref[$ftable][$rtable] is not set.
      *
      * @param $ftable name of referencing (foreign key) table
      * @param $rtable name of referenced table
      * @return void
      * @access public
-     */ 
-    function deleteRef($ftable, $rtable) 
+     */
+    function deleteRef($ftable, $rtable)
     {
         // Delete from $_ref property
         if (isset($this->_ref[$ftable])) {
@@ -1578,7 +1578,7 @@ class DB_Table_Database extends DB_Table_Base
             }
             foreach ($fkey as $column) {
                 if (isset($this->_foreign_col[$column])) {
-                    $key = array_search($ftable, 
+                    $key = array_search($ftable,
                                         $this->_foreign_col[$column]);
                     if (is_integer($key)) {
                         unset($this->_foreign_col[$column][$key]);
@@ -1596,7 +1596,7 @@ class DB_Table_Database extends DB_Table_Base
         // Delete from $_ref_to property
         if (isset($this->_ref_to[$rtable])) {
             $key = array_search($ftable, $this->_ref_to[$rtable]);
-            // Unset element 
+            // Unset element
             unset($this->_ref_to[$rtable][$key]);
             if (count($this->_ref_to[$rtable]) == 0) {
                 unset($this->_ref_to[$rtable]);
@@ -1624,22 +1624,22 @@ class DB_Table_Database extends DB_Table_Base
      * from $ftable to $rtable. The parameter action may be one of the action
      * strings 'cascade', 'restrict', 'set null', or 'set default', or it may
      * be php null. A null value of $action indicates that no action should be
-     * taken upon deletion of a referenced row. 
+     * taken upon deletion of a referenced row.
      *
      * Returns true on success, and PEAR error on failure. Returns the error
-     * code DB_TABLE_DATABASE_ERR_REF_TRIG_ACTION if $action is a neither a 
-     * valid action string nor null. Returns true, and does nothing, if 
-     * $this->_ref[$ftable][$rtable] is not set. 
+     * code DB_TABLE_DATABASE_ERR_REF_TRIG_ACTION if $action is a neither a
+     * valid action string nor null. Returns true, and does nothing, if
+     * $this->_ref[$ftable][$rtable] is not set.
      *
      * @param  string $ftable  name of referencing (foreign key) table
      * @param  string $rtable  name of referenced table
      * @param  string $action  on delete action (action string or null)
      * @return boolean true on normal completion (PEAR_Error on failure)
      * @access public
-     */ 
+     */
     function setOnDelete($ftable, $rtable, $action)
     {
-        $valid_actions = 
+        $valid_actions =
              array(null, 'cascade', 'set null', 'set default', 'restrict');
 
         if (isset($this->_ref[$ftable])) {
@@ -1665,10 +1665,10 @@ class DB_Table_Database extends DB_Table_Base
      * @param array  $action  on update action (action string or null)
      * @return boolean true on normal completion (PEAR_Error on failure)
      * @access public
-     */ 
+     */
     function setOnUpdate($ftable, $rtable, $action)
     {
-        $valid_actions = 
+        $valid_actions =
              array(null, 'cascade', 'set null', 'set default', 'restrict');
 
         if (isset($this->_ref[$ftable])) {
@@ -1687,13 +1687,13 @@ class DB_Table_Database extends DB_Table_Base
     /**
      * Identifies a linking/association table that links two others
      *
-     * Adds table name $link to $this->_link[$table1][$table2] and 
+     * Adds table name $link to $this->_link[$table1][$table2] and
      * to $this->_link[$table2][$table1].
      *
      * Returns true on success, and PEAR error on failure. Returns the
      * following DB_TABLE_DATABASE_ERR_* error codes if:
-     *   - $ftable does not exist ( _NO_FTABLE )
-     *   - $rtable does not exist ( _NO_RTABLE )
+     *   - $ftable does not exist (_NO_FTABLE )
+     *   - $rtable does not exist (_NO_RTABLE )
      *
      * @param  string $table1 name of 1st linked table
      * @param  string $table2 name of 2nd linked table
@@ -1758,7 +1758,7 @@ class DB_Table_Database extends DB_Table_Base
         }
         if (!key_exists($table1, $this->_link[$table2])) {
             $this->_link[$table2][$table1] = array();
-        } 
+        }
         $this->_link[$table2][$table1][] = $link;
     }
 
@@ -1766,9 +1766,9 @@ class DB_Table_Database extends DB_Table_Base
      * Adds all possible linking tables to the $_link property array
      *
      * Identifies all potential linking tables in the datbase, and adds
-     * them all to the $_link property.  Table $link is taken to be a 
-     * link between tables $table1 and $table2 if it contains foreign 
-     * key references to both $table1 and $table2. 
+     * them all to the $_link property.  Table $link is taken to be a
+     * link between tables $table1 and $table2 if it contains foreign
+     * key references to both $table1 and $table2.
      *
      * @return void
      * @access public
@@ -1809,7 +1809,7 @@ class DB_Table_Database extends DB_Table_Base
      *
      * If $link is not null, remove table $link from the list of links
      * between $table1 and $table2, if present. If $link is null, delete
-     * all links between $table1 and $table2. 
+     * all links between $table1 and $table2.
      *
      * @param  string $table1 name of 1st linked table
      * @param  string $table2 name of 2nd linked table
@@ -1835,7 +1835,7 @@ class DB_Table_Database extends DB_Table_Base
                             if (count($this->_link[$table2]) == 0) {
                                 unset($this->_link[$table2]);
                             }
-                        } else { 
+                        } else {
                             // Reset remaining indices sequentially from zero
                             $new = array_values($this->_link[$table1][$table2]);
                             $this->_link[$table1][$table2] = $new;
@@ -1862,46 +1862,46 @@ class DB_Table_Database extends DB_Table_Base
      * The parameter $col is a string may be either a column name or
      * a column name qualified by a table name, using the SQL syntax
      * "$table.$column". If $col contains a table name, and is valid,
-     * an array($table, $column) is returned.  If $col is not qualified 
+     * an array($table, $column) is returned.  If $col is not qualified
      * by a column name, an array array($table, $column) is returned,
      * in which $table is either the name of one table, or an array
-     * containing the names of two or more tables containing a column 
-     * named $col. 
+     * containing the names of two or more tables containing a column
+     * named $col.
      *
      * The $from parameter, if present, is a numerical array of
      * names of tables with which $col should be associated, if no
-     * explicit table name is provided, and if possible. If one 
-     * or more of the tables in $from contains a column $col, the 
-     * returned table or set of tables is restricted to those in 
+     * explicit table name is provided, and if possible. If one
+     * or more of the tables in $from contains a column $col, the
+     * returned table or set of tables is restricted to those in
      * array $from.
      *
      * If the table name remains ambiguous after testing for tables in
-     * the $from set, and $col is not a foreign key in one or more of 
-     * the remaining tables, the returned table or set of tables is 
-     * restricted to those in which $col is not a foreign key. 
+     * the $from set, and $col is not a foreign key in one or more of
+     * the remaining tables, the returned table or set of tables is
+     * restricted to those in which $col is not a foreign key.
      *
      * Returns a PEAR_Error with the following DB_TABLE_DATABASE_ERR_* error
      * codes if:
-     *    - column $col does not exist in the database ( _NO_COL_DB )
-     *    - column $col does not exist in the specified table ( _NO_COL_TBL )
-     * 
+     *    - column $col does not exist in the database (_NO_COL_DB )
+     *    - column $col does not exist in the specified table (_NO_COL_TBL )
+     *
      * @param  string $col  column name, optionally qualified by a table name
      * @param  array  $from array of tables from which $col should be chosen,
      *                      if possible.
-     * @return array  array($table, $column), or PEAR_Error 
+     * @return array  array($table, $column), or PEAR_Error
                       $column is a string, $table is a string or array
      * @access public
      */
     function validCol($col, $from = null)
     {
         $col = explode('.',trim($col));
-        if (count($col) == 1) { 
+        if (count($col) == 1) {
             // Parameter $col is a column name with no table name
             $column = $col[0];
             // Does $column exist in database ?
             if (!isset($this->_col[$column])) {
                 return $this->throwError(
-                          DB_TABLE_DATABASE_ERR_NO_COL_DB, 
+                          DB_TABLE_DATABASE_ERR_NO_COL_DB,
                           "$column");
             }
             $table = $this->_col[$column];
@@ -1923,7 +1923,7 @@ class DB_Table_Database extends DB_Table_Base
             if (count($table) == 1) {
                 $table = $table[0];
             }
-        } elseif (count($col) == 2) { 
+        } elseif (count($col) == 2) {
             // parameter $col is qualified by a table name
             $table  = $col[0];
             $column = $col[1];
@@ -1942,7 +1942,7 @@ class DB_Table_Database extends DB_Table_Base
         }
         return array($table, $column);
     }
- 
+
 
     /**
      * Creates all the tables in a database in a RDBMS
@@ -1958,7 +1958,7 @@ class DB_Table_Database extends DB_Table_Base
      *                    applied to each table in the database. It can have
      *                    values:
      *                    - 'safe' to create a table only if it does not exist
-     *                    - 'drop' to drop and recreate any existing table 
+     *                    - 'drop' to drop and recreate any existing table
                              with the same name
      *
      * @see DB_Table::create()
@@ -1982,14 +1982,14 @@ class DB_Table_Database extends DB_Table_Base
      * containing values to be inserted or updated in table $table_name.
      *
      * Returns true if each foreign key in $data matches a row in the
-     * referenced table, or if there are no foreign key columns in $data.  
+     * referenced table, or if there are no foreign key columns in $data.
      * Returns false if any foreign key column in associative array $data
-     * (which may contain a full or partial row of $table_name), does not 
-     * match the the value of the referenced column in any row of the 
+     * (which may contain a full or partial row of $table_name), does not
+     * match the the value of the referenced column in any row of the
      * referenced table.
      *
-     * Returns any PEAR error thrown by the select method, which is called 
-     * to implement the required query, or by the buildFilter method. 
+     * Returns any PEAR error thrown by the select method, which is called
+     * to implement the required query, or by the buildFilter method.
      *
      * @param $table_name name of the referencing table containing $data
      * @param @data       associative array containing all or part of a row
@@ -2027,7 +2027,7 @@ class DB_Table_Database extends DB_Table_Base
                     }
                     // Check for failed foreign key constraint
                     if (count($referenced_rows) == 0) {
-                        return $this->throwError( 
+                        return $this->throwError(
                                DB_TABLE_DATABASE_ERR_FKEY_CONSTRAINT);
                     }
                 }
@@ -2037,7 +2037,7 @@ class DB_Table_Database extends DB_Table_Base
     }
 
     /**
-     * Inserts a single table row 
+     * Inserts a single table row
      *
      * Wrapper for insert method of the corresponding DB_Table object.
      *
@@ -2158,7 +2158,7 @@ class DB_Table_Database extends DB_Table_Base
                 // Check if any column(s) of referenced $rkey are updated
                 $rkey_updated = false;
                 foreach ($data as $key => $value) {
-                    if (is_string($rkey)){
+                    if (is_string($rkey)) {
                         if ($key == $rkey) {
                             $rkey_updated = true;
                             break;
@@ -2259,9 +2259,9 @@ class DB_Table_Database extends DB_Table_Base
                         }
 
                         // Construct filter for rows that reference $update_row
-                        $filter = $this->_buildFKeyFilter($update_row, 
+                        $filter = $this->_buildFKeyFilter($update_row,
                                                           $rkey, $fkey);
-    
+
                         // Apply action to foreign/referencing rows
                         if ($action == 'restrict') {
                             $sql = array('select'=>'*',
@@ -2283,7 +2283,7 @@ class DB_Table_Database extends DB_Table_Base
                             // during update, then restore original value
                             $check_fkey = $this->_check_fkey;
                             $this->_check_fkey = false;
-                            $result = $this->update($ftable_name, $fdata, 
+                            $result = $this->update($ftable_name, $fdata,
                                                     $filter);
                             $this->_check_fkey = $check_fkey;
                             if (PEAR::isError($result)) {
@@ -2378,7 +2378,7 @@ class DB_Table_Database extends DB_Table_Base
                 $action = $ref['on_delete'];
                 if (is_null($action)) {
                    continue;
-                } 
+                }
                 $ftable_obj =& $this->_table[$ftable_name];
                 $rtable_obj =& $this->_table[$table_name];
                 $fkey = $ref['fkey'];
@@ -2436,7 +2436,7 @@ class DB_Table_Database extends DB_Table_Base
                     }
 
                     // Construct filter for referencing rows in $ftable_name
-                    $filter = $this->_buildFKeyFilter($delete_row, 
+                    $filter = $this->_buildFKeyFilter($delete_row,
                                                       $rkey, $fkey);
 
                     // Apply action for one deleted row
@@ -2483,7 +2483,7 @@ class DB_Table_Database extends DB_Table_Base
                 } // end foreach ($delete_rows)
 
             } // end foreach ($this->_ref_to[...] as $ftable_name)
-        } // end if 
+        } // end if
 
     }
 
@@ -2492,10 +2492,10 @@ class DB_Table_Database extends DB_Table_Base
      * Returns array in which keys of $data are replaced by values of $keys.
      *
      * This function is used by the insert() and update() methods to restore
-     * the case of column names in associative arrays that are returned from 
+     * the case of column names in associative arrays that are returned from
      * an automatically generated query "SELECT * FROM $table WHERE ...", when
-     * these column name keys are returned with a fixed case. In this usage, 
-     * $keys is a sequential array of the names of all columns in $table. 
+     * these column name keys are returned with a fixed case. In this usage,
+     * $keys is a sequential array of the names of all columns in $table.
      *
      * @param  array $data associative array
      * @param  array $key  numerical array of replacement key names
@@ -2503,7 +2503,7 @@ class DB_Table_Database extends DB_Table_Base
      *               by the values of array $keys.
      * @access private
      */
-    function _replaceKeys($data, $keys) 
+    function _replaceKeys($data, $keys)
     {
         $new_data = array();
         $i = 0;
@@ -2516,16 +2516,16 @@ class DB_Table_Database extends DB_Table_Base
     }
 
     /**
-     * Builds a select command involving joined tables from 
+     * Builds a select command involving joined tables from
      * a list of column names and/or a list of table names.
      *
      * Returns an query array of the form used in $this->buildSQL,
      * constructed on the basis of a sequential array $cols of
      * column names and/or a sequential array $tables of table
-     * names.  The 'FROM' clause in the resulting SQL contains 
-     * all the table listed in the $tables parameter and all 
+     * names.  The 'FROM' clause in the resulting SQL contains
+     * all the table listed in the $tables parameter and all
      * those containing the columns listed in the $cols array,
-     * as well as any linking tables required to establish 
+     * as well as any linking tables required to establish
      * many to many relationships between these tables. The
      * 'WHERE' clause is constructed so as to create an inner
      * join of these tables.
@@ -2533,17 +2533,17 @@ class DB_Table_Database extends DB_Table_Base
      * The $cols parameter is a sequential array in which the
      * values are column names. Column names may be qualified
      * by a table name, using the SQL table.column syntax, but
-     * need not be qualified if they are unambiguous. The 
-     * values in $cols can only be column names, and may not 
+     * need not be qualified if they are unambiguous. The
+     * values in $cols can only be column names, and may not
      * be functions or more complicated SQL expressions. If
-     * cols is null, the resulting SQL command will start with 
+     * cols is null, the resulting SQL command will start with
      * 'SELECT * FROM ...' .
      *
      * The $tables parameter is a sequential array in which the
      * values are table names. If $tables is null, the FROM
      * clause is constructed from the tables containing the
-     * columns in the $cols. 
-     * 
+     * columns in the $cols.
+     *
      * The $params array is an associative array can have
      * 'filter', and 'order' keys, which are both optional.
      * A value $params['filter'] is an condition string to
@@ -2561,7 +2561,7 @@ class DB_Table_Database extends DB_Table_Base
      *
      * @param  array $cols   sequential array of column names
      * @param  array $tables sequential array of table names
-     * @param  array $filter SQL logical expression to be added 
+     * @param  array $filter SQL logical expression to be added
      *                       (ANDed) to the where clause
      * @return array sql query array for select statement
      * @access public
@@ -2618,8 +2618,8 @@ class DB_Table_Database extends DB_Table_Base
             $link_tables = array();           // list of required linking tables
             $joins       = array();           // list of join conditions
             // Initialize linked list of unjoined tables
-            $next  = array();                  
-            for ( $i=1 ; $i < $n_tables-1 ; $i++) {
+            $next  = array();
+            for ($i=1 ; $i < $n_tables-1 ; $i++) {
                 $next[$tables[$i]]   = $tables[$i+1];
                 $prev[$tables[$i+1]] = $tables[$i];
             }
@@ -2652,7 +2652,7 @@ class DB_Table_Database extends DB_Table_Base
                                     for ($i=0; $i < count($fkey); $i++ ) {
                                         $fcol = $fkey[$i];
                                         $rcol = $rkey[$i];
-                                        $joins[] = 
+                                        $joins[] =
                                                "$table1.$fcol = $table2.$rcol";
                                     }
                                 }
@@ -2680,7 +2680,7 @@ class DB_Table_Database extends DB_Table_Base
                                     for ($i=0; $i < count($fkey); $i++ ) {
                                         $fcol = $fkey[$i];
                                         $rcol = $rkey[$i];
-                                        $joins[] = 
+                                        $joins[] =
                                                "$table2.$fcol = $table1.$rcol";
                                     }
                                 }
@@ -2716,7 +2716,7 @@ class DB_Table_Database extends DB_Table_Base
                                     for ($i=0; $i < count($fkey1); $i++ ) {
                                         $fcol1 = $fkey1[$i];
                                         $rcol1 = $rkey1[$i];
-                                        $joins[] = 
+                                        $joins[] =
                                                "$link.$fcol1 = $table1.$rcol1";
                                     }
                                 }
@@ -2729,7 +2729,7 @@ class DB_Table_Database extends DB_Table_Base
                                     for ($i=0; $i < count($fkey2); $i++ ) {
                                         $fcol2 = $fkey2[$i];
                                         $rcol2 = $rkey2[$i];
-                                        $joins[] = 
+                                        $joins[] =
                                               "$link.$fcol2 = $table2.$rcol2";
                                     }
                                 }
@@ -2767,7 +2767,7 @@ class DB_Table_Database extends DB_Table_Base
 
             }
 
-            // Add any required linking tables to $tables array 
+            // Add any required linking tables to $tables array
             if ($link_tables) {
                 foreach ($link_tables as $link) {
                     if (!in_array($link, $tables)) {
@@ -2787,8 +2787,8 @@ class DB_Table_Database extends DB_Table_Base
         // Add $filter condition, if present
         if ($filter) {
            if (isset($query['where'])) {
-               $query['where'] = '( ' . $query['where'] . " )\n" .
-                           '  AND ( ' . $filter . ')';
+               $query['where'] = '(' . $query['where'] . " )\n" .
+                           '  AND (' . $filter . ')';
            } else {
                $query['where'] = $filter;
            }
@@ -2799,77 +2799,77 @@ class DB_Table_Database extends DB_Table_Base
 
 
     /**
-     * Returns WHERE clause equating values of $data array to database column 
+     * Returns WHERE clause equating values of $data array to database column
      * values
      *
-     * Usage: In the simplest usage of this method, which is obtained when 
-     * both $data_key and $filt_key are null or absent, the method returns an 
+     * Usage: In the simplest usage of this method, which is obtained when
+     * both $data_key and $filt_key are null or absent, the method returns an
      * SQL logical expression that equates the values of $data to the values
-     * of database columns whose names are given by the keys of $data. In 
-     * the general case, function is designed to return an SQL logical 
+     * of database columns whose names are given by the keys of $data. In
+     * the general case, function is designed to return an SQL logical
      * expression that equates the values of a set of foreign key columns in
      * associative array $data, which is a row to be inserted or updated in
-     * one table, to the values of the corresponding columns of a referenced 
+     * one table, to the values of the corresponding columns of a referenced
      * table. In this usage, $data_key is the foreign key (a column name or
      * numerical array of column names), and $filt_key is the corresponding
-     * referenced key. 
-     * 
-     * Parameters: Parameter $data is an associative array containing data to 
+     * referenced key.
+     *
+     * Parameters: Parameter $data is an associative array containing data to
      * be inserted into or used to update one row of a database table, in which
      * array keys are column names. When present, $data_key contains either
      * the name of a single array key of interest, or a numerical array of such
-     * keys. These are usually the names of the columns of a foreign key in 
-     * that table. When, $data_key is null or absent, it is taken to be equal 
+     * keys. These are usually the names of the columns of a foreign key in
+     * that table. When, $data_key is null or absent, it is taken to be equal
      * to an array containing all of the keys of $data. When present, $filt_key
-     * contains either a string or a numerical array of strings that are 
+     * contains either a string or a numerical array of strings that are
      * aliases for the keys in $data_key.  These are usually the names of the
-     * corresponding columns in the referenced table. When $filt_key is null 
-     * or absent, it is equated with $data_key internally.  The function 
-     * returns an SQL logical expression that equates the values in $data 
-     * whose keys are specified by $data_key, to the values of database 
-     * columns whose names are specified in $filt_key. 
+     * corresponding columns in the referenced table. When $filt_key is null
+     * or absent, it is equated with $data_key internally.  The function
+     * returns an SQL logical expression that equates the values in $data
+     * whose keys are specified by $data_key, to the values of database
+     * columns whose names are specified in $filt_key.
      *
      * Simple case: If parameters $data_key and $filt_key are null, and
      * <code>
-     *     $data = array( 'c1' => $v1, 'c2' => $v2, 'c3' => $v3)
+     *     $data = array('c1' => $v1, 'c2' => $v2, 'c3' => $v3)
      * </code>
-     * then buildFilter($data) returns a string 
+     * then buildFilter($data) returns a string
      * <code>
      *     "c1 => $val1 AND c2 => $val2 AND c3 = $v3"
      * </code>
      * in which the values $v1, $v2, $v3 are replaced by SQL literal values,
      * quoted and escaped as appropriate for each data type and the backend
-     * RDBMS. 
+     * RDBMS.
      *
      * General case: Buildfilter returns a SQL logical exprssion that equates
      * the values of $data whose keys are given in $data_key with the values
      * values of database columns with names given in $filt_key. For example,
      * if
      * <code>
-     *    $data = array( 'k1' => $v1, 'k2' => $v2, ... , 'k10' => $v10 );
+     *    $data = array('k1' => $v1, 'k2' => $v2, ... , 'k10' => $v10 );
      *    $data_key = array('k2', 'k5', 'k7');
      *    $filt_key = array('c2', 'c5', 'c7');
      * </code>
      * then buildFilter($data, $data_key, $filt_key) returns a string
      * <code>
-     *    "c2 = $v2 AND c5 = $v5 AND c7 = $v7" 
+     *    "c2 = $v2 AND c5 = $v5 AND c7 = $v7"
      * </code>
-     * in which the values $v2, $v5, $v7 are replaced by properly quoted 
-     * SQL literal values. If, in the above example, $data_key = 'k5' and 
+     * in which the values $v2, $v5, $v7 are replaced by properly quoted
+     * SQL literal values. If, in the above example, $data_key = 'k5' and
      * $filt_key = 'c5', then the function will return
      * <code>
-     *    "c5 = $v5" 
+     *    "c5 = $v5"
      * </code>
-     * where (again) $v5 is replaced by an SQL literal. 
+     * where (again) $v5 is replaced by an SQL literal.
      *
      * Quoting is done by the DB_Table_Database::quote() method, based on
-     * the php type of the values in $array.  The treatment of null values 
+     * the php type of the values in $array.  The treatment of null values
      * in $data depends upon the value of the $match parameter.
      *
-     * Null values: The treatment to null values in $data depends upon 
+     * Null values: The treatment to null values in $data depends upon
      * the value of the $match parameter . If $match == 'simple', an empty
      * string is returned if any $value of $data with a key in $data_key
-     * is null. If $match == 'partial', the returned SQL expression 
+     * is null. If $match == 'partial', the returned SQL expression
      * equates only the relevant non-null values of $data to the values of
      * corresponding database columns. If $match == 'full', the function
      * returns an empty string if all of the relevant values of data are
@@ -2883,11 +2883,11 @@ class DB_Table_Database extends DB_Table_Base
      *                        values are names of a corresponding set of
      *                        database column names.
      * @return string SQL expression equating values in $data, for which keys
-     *                also appear in $data_key, to values of corresponding 
+     *                also appear in $data_key, to values of corresponding
      *                database columns named in $filt_key.
      * @access private
      */
-    function _buildFKeyFilter($data, $data_key = null, $filt_key = null, 
+    function _buildFKeyFilter($data, $data_key = null, $filt_key = null,
                               $match = 'simple')
     {
         // Check $match type value
@@ -2966,15 +2966,15 @@ class DB_Table_Database extends DB_Table_Base
     /**
     * Returns SQL literal string representation of a php value
     *
-    * If $value is: 
+    * If $value is:
     *    - a string, return the string enquoted and escaped
     *    - a number, return cast of number to string, without quotes
     *    - a boolean, return '1' for true and '0' for false
     *    - null, return the string 'NULL'
-    * 
-    * @param  mixed  $value 
+    *
+    * @param  mixed  $value
     * @return string representation of value as an SQL literal
-    * 
+    *
     * @see DB_Common::quoteSmart()
     * @see MDB2::quote()
     * @access public
@@ -2983,7 +2983,7 @@ class DB_Table_Database extends DB_Table_Base
     {
         if (is_bool($value)) {
            return $value ? '1' : '0';
-        } 
+        }
         if ($this->backend == 'mdb2') {
             $value = $this->db->quote($value);
         } else {
@@ -2991,7 +2991,7 @@ class DB_Table_Database extends DB_Table_Base
         }
         return (string) $value;
     }
-    
+
     /**
      * Serializes all table references and sets $db = null, $backend = null
      *
@@ -3015,11 +3015,11 @@ class DB_Table_Database extends DB_Table_Base
     /**
      * Unserializes child DB_Table objects
      *
-     * Immediately after unserialization, a DB_Table_Databse object 
-     * has null $db and $backend properties, and each of its child 
+     * Immediately after unserialization, a DB_Table_Databse object
+     * has null $db and $backend properties, and each of its child
      * DB_Table objects has null $db and $backend properties. The
-     * DB_Table_Database::setDB method should be called immediately 
-     * after unserialization to re-establish the database connection, 
+     * DB_Table_Database::setDB method should be called immediately
+     * after unserialization to re-establish the database connection,
      * like so:
      * <code>
      *    $db_object = unserialize($serialized_db);
@@ -3073,10 +3073,10 @@ class DB_Table_Database extends DB_Table_Base
      * Returns a DB_Table_Database object constructed from an XML string
      *
      * Uses the MDB2 XML schema for a database element, including a new
-     * syntax for foreign key indices. 
+     * syntax for foreign key indices.
      *
      * NOTE: This function requires PHP 5. It throws an error if used
-     * with PHP 4. 
+     * with PHP 4.
      *
      * @param  string XML string representation
      * @return object DB_Table_Database object on success, or error on failure
@@ -3097,21 +3097,21 @@ class DB_Table_Database extends DB_Table_Base
             return $this->throwError(
                    DB_TABLE_DATABASE_ERR_XML_PARSE);
         }
-    
+
         // Instantiate database object
         $database_name = (string) $xml->name;
         $database_obj  = new DB_Table_Database($conn, $database_name);
-   
+
         // Create array of foreign key references
         $ref = array();
-   
+
         // Loop over tables
         foreach ($xml->table as $table) {
             $table_name = (string) $table->name;
-    
+
             // Instantiate table object
             $table_obj = new DB_Table($conn, $table_name);
-        
+
             // Add columns to table object
             $declaration = $table->declaration;
             foreach ($declaration->field as $field) {
@@ -3141,8 +3141,8 @@ class DB_Table_Database extends DB_Table_Base
                 }
                 $table_obj->col[$col_name] = $def;
             }
-        
-            // Add indices 
+
+            // Add indices
             foreach ($declaration->index as $index) {
                 if (isset($index->name)) {
                     $name = (string) $index->name;

--- a/tests/PEAR_Error/pear_error.phpt
+++ b/tests/PEAR_Error/pear_error.phpt
@@ -56,17 +56,17 @@ set_error_handler("test_error_handler");
 
 class Foo_Error extends PEAR_Error
 {
-    function Foo_Error($message = "unknown error", $code = null,
+    function __construct($message = "unknown error", $code = null,
                        $mode = null, $options = null, $userinfo = null)
     {
-        $this->PEAR_Error($message, $code, $mode, $options, $userinfo);
+        parent::__construct($message, $code, $mode, $options, $userinfo);
         $this->error_message_prefix = 'Foo_Error prefix';
     }
 }
 
 class Test1 extends PEAR {
-    function Test1() {
-        $this->PEAR("Foo_Error");
+    function __construct() {
+        parent::__construct("Foo_Error");
     }
     function runtest() {
         return $this->raiseError("test error");

--- a/tests/download_test_classes.php.inc
+++ b/tests/download_test_classes.php.inc
@@ -111,7 +111,7 @@ class test_PEAR_REST extends PEAR_REST {
 
 require_once 'PEAR/REST/10.php';
 class test_PEAR_REST_10 extends PEAR_REST_10 {
-    function test_PEAR_REST_10($config, $options = array())
+    function __construct($config, $options = array())
     {
         $this->_rest = new test_PEAR_REST($config, $options);
     }
@@ -119,7 +119,7 @@ class test_PEAR_REST_10 extends PEAR_REST_10 {
 
 require_once 'PEAR/REST/13.php';
 class test_PEAR_REST_13 extends PEAR_REST_13 {
-    function test_PEAR_REST_13($config, $options = array())
+    function __construct($config, $options = array())
     {
         $this->_rest = new test_PEAR_REST($config, $options);
     }
@@ -289,9 +289,9 @@ class test_PEAR_Installer extends PEAR_Installer {
 
 require_once 'PEAR/Downloader.php';
 class test_PEAR_Downloader extends PEAR_Downloader {
-    function test_PEAR_Downloader(&$ui, $options, &$config)
+    function __construct(&$ui, $options, &$config)
     {
-        parent::PEAR_Downloader($ui, $options, $config);
+        parent::__construct($ui, $options, $config);
     }
 
     /**

--- a/tests/pear_autoloader.phpt
+++ b/tests/pear_autoloader.phpt
@@ -9,7 +9,7 @@ skip
 include dirname(__FILE__)."/../PEAR/Autoloader.php";
 
 class test1 extends PEAR_Autoloader {
-    function test1() {
+    function __construct() {
 	$this->addAutoload(array(
 	    'testfunc1' => 'testclass1',
 	    'testfunca' => 'testclass1',

--- a/tests/php_dump.php.inc
+++ b/tests/php_dump.php.inc
@@ -1,7 +1,7 @@
 <?php
 class PHP_Dump {
     var $_var;
-    function PHP_Dump($var)
+    function __construct($var)
     {
         $this->_var = $var;
     }

--- a/tests/phpt_test.php.inc
+++ b/tests/phpt_test.php.inc
@@ -12,7 +12,7 @@ class PEAR_PHPTest
 {
     var $_diffonly;
     var $_errors;
-    function PEAR_PHPTest($diffonly = false, $noStackCatch = false)
+    function __construct($diffonly = false, $noStackCatch = false)
     {
         $this->_diffonly = $diffonly;
         $this->_errors = array();


### PR DESCRIPTION
This was done manually (i.e. without any Coding Standards scripts) to ensure absolutely minimal changes were made.
