### PR TITLE
add --showdiff to pear run-tests which will print the diff for the failed tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ php:
   - 5.4
 script:
   - umask 0022
-  - sh scripts/pear.sh run-tests -q -r tests
+  - sh scripts/pear.sh run-tests -q -d -r tests

--- a/PEAR/Command/Test.php
+++ b/PEAR/Command/Test.php
@@ -87,6 +87,10 @@ If none is found, all .phpt tests will be tried instead.',
                     'shortopt' => 'x',
                     'doc'      => 'Generate a code coverage report (requires Xdebug 2.0.0+)',
                 ),
+                'showdiff' => array(
+                    'shortopt' => 'd',
+                    'doc' => 'Output diff on test failure',
+                ),
             ),
             'doc' => '[testfile|dir ...]
 Run regression tests with PHP\'s regression testing script (run-tests.php).',

--- a/PEAR/RunTest.php
+++ b/PEAR/RunTest.php
@@ -637,6 +637,11 @@ class PEAR_RunTest
         $expectf = isset($section_text['EXPECTF']) ? $wanted_re : null;
         $data = $this->generate_diff($wanted, $output, $returns, $expectf);
         $res  = $this->_writeLog($diff_filename, $data);
+        if (isset($this->_options['showdiff'])) {
+            $this->_logger->log(0, "========DIFF========");
+            $this->_logger->log(0, $data);
+            $this->_logger->log(0, "========DONE========");
+        }
         if (PEAR::isError($res)) {
             return $res;
         }

--- a/tests/PEAR_Command/test_registerCommands_standard.phpt
+++ b/tests/PEAR_Command/test_registerCommands_standard.phpt
@@ -254,7 +254,7 @@ PEAR_Command::getGetoptArgs('remote-list', $s, $l);
 $phpunit->assertEquals('c:', $s, 'short remote-list');
 $phpunit->assertEquals(array ('channel='), $l, 'long remote-list');
 PEAR_Command::getGetoptArgs('run-tests', $s, $l);
-$phpunit->assertEquals('ri:lqsputc:x', $s, 'short run-tests');
+$phpunit->assertEquals('ri:lqsputc:xd', $s, 'short run-tests');
 $phpunit->assertEquals(array (
     'recur',
     'ini=',
@@ -265,7 +265,8 @@ $phpunit->assertEquals(array (
     'phpunit',
     'tapoutput',
     'cgi=',
-    'coverage'), $l, 'long run-tests');
+    'coverage',
+    'showdiff'), $l, 'long run-tests');
 PEAR_Command::getGetoptArgs('search', $s, $l);
 $phpunit->assertEquals('c:ai', $s, 'short search');
 $phpunit->assertEquals(array ('channel=', 'allchannels', 'channelinfo'), $l, 'long search');


### PR DESCRIPTION
while debugging test failures it was a pita to alway manually open the diff file for the failed tests, we also have an option like this for php-src's run-tests.php and this could be also useful for the travis build.