### PR TITLE
Removed last of the PHP 4 style constructors.

### DIFF
--- a/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table.php
+++ b/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table.php
@@ -599,7 +599,7 @@ class DB_Table extends DB_Table_Base
      * @return object DB_Table
      * @access public
      */
-    function DB_Table(&$db, $table, $create = false)
+    function __construct(&$db, $table, $create = false)
     {
         // is the first argument a DB/MDB2 object?
         $this->backend = null;

--- a/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Database.php
+++ b/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Database.php
@@ -582,7 +582,7 @@ class DB_Table_Database extends DB_Table_Base
      * @return object DB_Table_Database
      * @access public
      */
-    function DB_Table_Database(&$db, $name)
+    function __construct(&$db, $name)
     {
         // Is $db an DB/MDB2 object or null?
         if (is_a($db, 'db_common')) {

--- a/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Date.php
+++ b/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Date.php
@@ -77,7 +77,7 @@ class DB_Table_Date {
      * @access public
      * @param string $date A date in ISO 8601 format.
      */
-    function DB_Table_Date($date)
+    function __construct($date)
     {
 		// This regex is very loose and accepts almost any butchered
 		// format you could throw at it.  e.g. 2003-10-07 19:45:15 and

--- a/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Generator.php
+++ b/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Generator.php
@@ -312,7 +312,7 @@ class DB_Table_Generator
      * @return object DB_Table_Generator
      * @access public
      */
-    function DB_Table_Generator(&$db, $name)
+    function __construct(&$db, $name)
     {
         // Is $db an DB/MDB2 object or null?
         if (is_a($db, 'db_common')) {

--- a/tests/PEAR_Installer_Role/roles/Common.php
+++ b/tests/PEAR_Installer_Role/roles/Common.php
@@ -38,7 +38,7 @@ class PEAR_Installer_Role_Common
     /**
      * @param PEAR_Config
      */
-    function PEAR_Installer_Role_Common(&$config)
+    function __construct(&$config)
     {
         $this->config = $config;
     }


### PR DESCRIPTION
Found with the following:

    $ phpcs --standard=Squiz --report=csv  --extensions=php --sniffs=Generic.NamingConventions.ConstructorName . | cut -f1,2 -d,