### PR TITLE
fix installer for PHP 7

### DIFF
--- a/install-pear.php
+++ b/install-pear.php
@@ -248,7 +248,7 @@ $options['upgrade'] = true;
 $install_root = getenv('INSTALL_ROOT');
 if (!empty($install_root)) {
     $options['packagingroot'] = $install_root;
-    $reg = &new PEAR_Registry($options['packagingroot'], false, false, $metadata_dir);
+    $reg = new PEAR_Registry($options['packagingroot'], false, false, $metadata_dir);
 } else {
     $reg = $config->getRegistry('default');
 }


### PR DESCRIPTION
This script is not distributed with PEAR, but is used in downstream distribution (e.g. Fedora) to bootstrap the PEAR installation.
