### PR TITLE
allow pear to work when cache_dir is not writable

### DIFF
--- a/PEAR/REST.php
+++ b/PEAR/REST.php
@@ -235,6 +235,13 @@ class PEAR_REST
             }
         }
 
+        if (!is_writeable($cache_dir)) {
+            // If writing to the cache dir is not going to work, silently do nothing.
+            // An ugly hack, but retains compat with PEAR 1.9.1 where many commands
+            // work fine as non-root user (w/out write access to default cache dir).
+            return true;
+        }
+
         if ($cacheid === null && $nochange) {
             $cacheid = unserialize(implode('', file($cacheidfile)));
         }


### PR DESCRIPTION
FYI, this small patch is applied for years in Fedora / Red Hat, fixing a small regression in 1.9.2