### PR TITLE
Issue metadata

### DIFF
--- a/PEAR/Command/Install.php
+++ b/PEAR/Command/Install.php
@@ -555,7 +555,13 @@ Run post-installation scripts in package <package>, if any exist.
             $packrootphp_dir = $this->installer->_prependPath(
                 $this->config->get('php_dir', null, 'pear.php.net'),
                 $options['packagingroot']);
-            $instreg = new PEAR_Registry($packrootphp_dir); // other instreg!
+            $metadata_dir = $this->config->get('metadata_dir', null, 'pear.php.net');
+            if ($metadata_dir) {
+                $metadata_dir = $this->installer->_prependPath(
+                    $metadata_dir,
+                    $options['packagingroot']);
+            }
+            $instreg = new PEAR_Registry($packrootphp_dir, false, false, $metadata_dir); // other instreg!
 
             if ($this->config->get('verbose') > 2) {
                 $this->ui->outputData('using package root: ' . $options['packagingroot']);

--- a/PEAR/Config.php
+++ b/PEAR/Config.php
@@ -507,7 +507,6 @@ class PEAR_Config extends PEAR
             'default' => PEAR_CONFIG_DEFAULT_METADATA_DIR,
             'doc' => 'directory where metadata files are installed (registry, filemap, channels, ...)',
             'prompt' => 'PEAR metadata directory',
-            'group' => 'File Locations',
             'group' => 'File Locations (Advanced)',
             ),
         // Maintainers

--- a/PEAR/Config.php
+++ b/PEAR/Config.php
@@ -86,6 +86,13 @@ if (getenv('PHP_PEAR_INSTALL_DIR')) {
     }
 }
 
+// Default for metadata_dir
+if (getenv('PHP_PEAR_METADATA_DIR')) {
+    define('PEAR_CONFIG_DEFAULT_METADATA_DIR', getenv('PHP_PEAR_METADATA_DIR'));
+} else {
+    define('PEAR_CONFIG_DEFAULT_METADATA_DIR', '');
+}
+
 // Default for ext_dir
 if (getenv('PHP_PEAR_EXTENSION_DIR')) {
     define('PEAR_CONFIG_DEFAULT_EXT_DIR', getenv('PHP_PEAR_EXTENSION_DIR'));
@@ -397,6 +404,13 @@ class PEAR_Config extends PEAR
             'prompt' => 'PEAR directory',
             'group' => 'File Locations',
             ),
+        'metadata_dir' => array(
+            'type' => 'directory',
+            'default' => PEAR_CONFIG_DEFAULT_METADATA_DIR,
+            'doc' => 'directory where metadata files are installed (registry, filemap, channels, ...)',
+            'prompt' => 'PEAR metadata directory',
+            'group' => 'File Locations',
+            ),
         'ext_dir' => array(
             'type' => 'directory',
             'default' => PEAR_CONFIG_DEFAULT_EXT_DIR,
@@ -646,7 +660,9 @@ class PEAR_Config extends PEAR
             $this->configuration['default'][$key] = $info['default'];
         }
 
-        $this->_registry['default'] = new PEAR_Registry($this->configuration['default']['php_dir']);
+        $this->_registry['default'] = new PEAR_Registry(
+            $this->configuration['default']['php_dir'], false, false,
+            $this->configuration['default']['metadata_dir']);
         $this->_registry['default']->setConfig($this, false);
         $this->_regInitialized['default'] = false;
         //$GLOBALS['_PEAR_Config_instance'] = &$this;
@@ -750,7 +766,9 @@ class PEAR_Config extends PEAR
         $this->configuration[$layer] = $data;
         $this->_setupChannels();
         if (!$this->_noRegistry && ($phpdir = $this->get('php_dir', $layer, 'pear.php.net'))) {
-            $this->_registry[$layer] = new PEAR_Registry($phpdir);
+            $this->_registry[$layer] = new PEAR_Registry(
+                $phpdir, false, false,
+                $this->get('metadata_dir', $layer, 'pear.php.net'));
             $this->_registry[$layer]->setConfig($this, false);
             $this->_regInitialized[$layer] = false;
         } else {
@@ -907,7 +925,9 @@ class PEAR_Config extends PEAR
 
         $this->_setupChannels();
         if (!$this->_noRegistry && ($phpdir = $this->get('php_dir', $layer, 'pear.php.net'))) {
-            $this->_registry[$layer] = new PEAR_Registry($phpdir);
+            $this->_registry[$layer] = new PEAR_Registry(
+                $phpdir, false, false,
+                $this->get('metadata_dir', $layer, 'pear.php.net'));
             $this->_registry[$layer]->setConfig($this, false);
             $this->_regInitialized[$layer] = false;
         } else {
@@ -1595,7 +1615,9 @@ class PEAR_Config extends PEAR
 
                 if (!is_object($this->_registry[$layer])) {
                     if ($phpdir = $this->get('php_dir', $layer, 'pear.php.net')) {
-                        $this->_registry[$layer] = new PEAR_Registry($phpdir);
+                        $this->_registry[$layer] = new PEAR_Registry(
+                            $phpdir, false, false,
+                            $this->get('metadata_dir', $layer, 'pear.php.net'));
                         $this->_registry[$layer]->setConfig($this, false);
                         $this->_regInitialized[$layer] = false;
                     } else {
@@ -2079,7 +2101,9 @@ class PEAR_Config extends PEAR
                     continue;
                 }
                 $this->_registry[$layer] =
-                    new PEAR_Registry($this->get('php_dir', $layer, 'pear.php.net'));
+                    new PEAR_Registry(
+                        $this->get('php_dir', $layer, 'pear.php.net'), false, false,
+                        $this->get('metadata_dir', $layer, 'pear.php.net'));
                 $this->_registry[$layer]->setConfig($this, false);
                 $this->_regInitialized[$layer] = false;
             }

--- a/PEAR/Config.php
+++ b/PEAR/Config.php
@@ -404,13 +404,6 @@ class PEAR_Config extends PEAR
             'prompt' => 'PEAR directory',
             'group' => 'File Locations',
             ),
-        'metadata_dir' => array(
-            'type' => 'directory',
-            'default' => PEAR_CONFIG_DEFAULT_METADATA_DIR,
-            'doc' => 'directory where metadata files are installed (registry, filemap, channels, ...)',
-            'prompt' => 'PEAR metadata directory',
-            'group' => 'File Locations',
-            ),
         'ext_dir' => array(
             'type' => 'directory',
             'default' => PEAR_CONFIG_DEFAULT_EXT_DIR,
@@ -507,6 +500,14 @@ class PEAR_Config extends PEAR
             'default' => '',
             'doc' => 'location of php.ini in which to enable PECL extensions on install',
             'prompt' => 'php.ini location',
+            'group' => 'File Locations (Advanced)',
+            ),
+        'metadata_dir' => array(
+            'type' => 'directory',
+            'default' => PEAR_CONFIG_DEFAULT_METADATA_DIR,
+            'doc' => 'directory where metadata files are installed (registry, filemap, channels, ...)',
+            'prompt' => 'PEAR metadata directory',
+            'group' => 'File Locations',
             'group' => 'File Locations (Advanced)',
             ),
         // Maintainers

--- a/PEAR/DependencyDB.php
+++ b/PEAR/DependencyDB.php
@@ -120,8 +120,11 @@ class PEAR_DependencyDB
 
         $this->_registry = &$this->_config->getRegistry();
         if (!$depdb) {
-            $this->_depdb = $this->_config->get('php_dir', null, 'pear.php.net') .
-                DIRECTORY_SEPARATOR . '.depdb';
+            $dir = $this->_config->get('metadata_dir', null, 'pear.php.net');
+            if (!$dir) {
+                $dir = $this->_config->get('php_dir', null, 'pear.php.net');
+            }
+            $this->_depdb =  $dir . DIRECTORY_SEPARATOR . '.depdb';
         } else {
             $this->_depdb = $depdb;
         }

--- a/PEAR/Downloader/Package.php
+++ b/PEAR/Downloader/Package.php
@@ -413,7 +413,7 @@ class PEAR_Downloader_Package
                 if ($param->_installRegistry->packageExists($package, $channel)) {
                     $packageVersion = $param->_installRegistry->packageInfo($package, 'version', $channel);
                     if (version_compare($packageVersion, $param->getVersion(), '==')) {
-                        if (!isset($options['force'])) {
+                        if (!isset($options['force']) && !isset($options['packagingroot'])) {
                             $info = $param->getParsedPackage();
                             unset($info['version']);
                             unset($info['state']);

--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -1128,15 +1128,6 @@ class PEAR_Installer extends PEAR_Downloader
 
         $pkgname = $pkg->getName();
         $channel = $pkg->getChannel();
-        if (isset($this->_options['packagingroot'])) {
-            $regdir = $this->_prependPath(
-                $this->config->get('php_dir', null, 'pear.php.net'),
-                $this->_options['packagingroot']);
-
-            $packrootphp_dir = $this->_prependPath(
-                $this->config->get('php_dir', null, $channel),
-                $this->_options['packagingroot']);
-        }
 
         if (isset($options['installroot'])) {
             $this->config->setInstallRoot($options['installroot']);
@@ -1148,7 +1139,21 @@ class PEAR_Installer extends PEAR_Downloader
             $this->config->setInstallRoot(false);
             $this->_registry = &$this->config->getRegistry();
             if (isset($this->_options['packagingroot'])) {
-                $installregistry = new PEAR_Registry($regdir);
+                $regdir = $this->_prependPath(
+                    $this->config->get('php_dir', null, 'pear.php.net'),
+                    $this->_options['packagingroot']);
+
+                $metadata_dir = $this->config->get('metadata_dir', null, 'pear.php.net');
+                if ($metadata_dir) {
+                    $metadata_dir = $this->_prependPath(
+                        $metadata_dir,
+                        $this->_options['packagingroot']);
+                }
+                $packrootphp_dir = $this->_prependPath(
+                    $this->config->get('php_dir', null, $channel),
+                    $this->_options['packagingroot']);
+
+                $installregistry = new PEAR_Registry($regdir, false, false, $metadata_dir);
                 if (!$installregistry->channelExists($channel, true)) {
                     // we need to fake a channel-discover of this channel
                     $chanobj = $this->_registry->getChannel($channel, true);

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -131,23 +131,26 @@ class PEAR_Registry extends PEAR
      * @access public
      */
     function __construct($pear_install_dir = PEAR_INSTALL_DIR, $pear_channel = false,
-                           $pecl_channel = false)
+                           $pecl_channel = false, $pear_metadata_dir = '')
     {
         parent::__construct();
-        $this->setInstallDir($pear_install_dir);
+        $this->setInstallDir($pear_install_dir, $pear_metadata_dir);
         $this->_pearChannel = $pear_channel;
         $this->_peclChannel = $pecl_channel;
         $this->_config      = false;
     }
 
-    function setInstallDir($pear_install_dir = PEAR_INSTALL_DIR)
+    function setInstallDir($pear_install_dir = PEAR_INSTALL_DIR, $pear_metadata_dir = '')
     {
         $ds = DIRECTORY_SEPARATOR;
         $this->install_dir = $pear_install_dir;
-        $this->channelsdir = $pear_install_dir.$ds.'.channels';
-        $this->statedir    = $pear_install_dir.$ds.'.registry';
-        $this->filemap     = $pear_install_dir.$ds.'.filemap';
-        $this->lockfile    = $pear_install_dir.$ds.'.lock';
+        if (!$pear_metadata_dir) {
+            $pear_metadata_dir = $pear_install_dir;
+        }
+        $this->channelsdir = $pear_metadata_dir.$ds.'.channels';
+        $this->statedir    = $pear_metadata_dir.$ds.'.registry';
+        $this->filemap     = $pear_metadata_dir.$ds.'.filemap';
+        $this->lockfile    = $pear_metadata_dir.$ds.'.lock';
     }
 
     function hasWriteAccess()
@@ -180,7 +183,7 @@ class PEAR_Registry extends PEAR
     {
         $this->_config = &$config;
         if ($resetInstallDir) {
-            $this->setInstallDir($config->get('php_dir'));
+            $this->setInstallDir($config->get('php_dir'), $config->get('metadata_dir'));
         }
     }
 
@@ -327,9 +330,9 @@ class PEAR_Registry extends PEAR
                 $this->_dependencyDB = &PEAR_DependencyDB::singleton($this->_config);
                 if (PEAR::isError($this->_dependencyDB)) {
                     // attempt to recover by removing the dep db
-                    if (file_exists($this->_config->get('php_dir', null, 'pear.php.net') .
+                    if (file_exists($this->_config->get('metadata_dir', null, 'pear.php.net') .
                         DIRECTORY_SEPARATOR . '.depdb')) {
-                        @unlink($this->_config->get('php_dir', null, 'pear.php.net') .
+                        @unlink($this->_config->get('metadata_dir', null, 'pear.php.net') .
                             DIRECTORY_SEPARATOR . '.depdb');
                     }
 

--- a/install-pear.php
+++ b/install-pear.php
@@ -2,7 +2,7 @@
 
 error_reporting(1803);
 
-if (ini_get('date.timezone') === '' && function_exists('date_default_timezone_set')) {
+if (ini_get('date.timezone') === '') {
     date_default_timezone_set('UTC');
 }
 


### PR DESCRIPTION
This change was already applied in master and we use this patch in Fedora (and RHEL/CentOS-7) since Nov 2012.

It should not change anything for common usage, but allow us to move the registry outside the pear directory (which is in the include_path) to /var/lib/pear (FHS compliance)