### PR TITLE
skip check (in base) when packagingroot used (different tree)

### DIFF
--- a/PEAR/Downloader/Package.php
+++ b/PEAR/Downloader/Package.php
@@ -425,7 +425,7 @@ class PEAR_Downloader_Package
                             $params[$i] = false;
                         }
                     } elseif (!isset($options['force']) && !isset($options['upgrade']) &&
-                          !isset($options['soft'])) {
+                          !isset($options['soft']) && !isset($options['packagingroot'])) {
                         $info = $param->getParsedPackage();
                         $param->_downloader->log(1, 'Skipping package "' .
                             $param->getShortName() .


### PR DESCRIPTION
To be consistent with PR #44 we also need to skip the check here.