### PR TITLE
fix https connection via proxy

### DIFF
--- a/PEAR/REST.php
+++ b/PEAR/REST.php
@@ -360,11 +360,7 @@ class PEAR_REST
         if ($this->config->get('http_proxy')&&
               $proxy = parse_url($this->config->get('http_proxy'))
         ) {
-            $proxy_host = isset($proxy['host']) ? $proxy['host'] : null;
-            if ($schema === 'https') {
-                $proxy_host = 'ssl://' . $proxy_host;
-            }
-
+            $proxy_host   = isset($proxy['host']) ? $proxy['host'] : null;
             $proxy_port   = isset($proxy['port']) ? $proxy['port'] : 8080;
             $proxy_user   = isset($proxy['user']) ? urldecode($proxy['user']) : null;
             $proxy_pass   = isset($proxy['pass']) ? urldecode($proxy['pass']) : null;


### PR DESCRIPTION
This seems related to a recent change to channel.xml and switch to https by default (only affect pecl channel, not pear one)

```
$ pear config-set http_proxy http://localhost:3128/
$ pecl channel-update -f pecl
$ pecl search oci
Connection to `ssl://localhost:3128' failed: 
```

BTW, I think proxy connection doesn't have to be adapted according to $schema (target) but to $proxy_schema
