### PR TITLE
Add proper HTTPS proxy support through the CONNECT verb

### DIFF
--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -20,6 +20,7 @@
  * Needed for constants, extending
  */
 require_once 'PEAR/Common.php';
+require_once 'PEAR/Proxy.php';
 
 define('PEAR_INSTALLER_OK',       1);
 define('PEAR_INSTALLER_FAILED',   0);
@@ -1584,20 +1585,10 @@ class PEAR_Downloader extends PEAR_Common
             $config = &PEAR_Config::singleton();
         }
 
-        $proxy_host = $proxy_port = $proxy_user = $proxy_pass = '';
-        if ($config->get('http_proxy') &&
-              $proxy = parse_url($config->get('http_proxy'))) {
-            $proxy_host = isset($proxy['host']) ? $proxy['host'] : null;
-            if (isset($proxy['scheme']) && $proxy['scheme'] == 'https') {
-                $proxy_host = 'ssl://' . $proxy_host;
-            }
-            $proxy_port = isset($proxy['port']) ? $proxy['port'] : 8080;
-            $proxy_user = isset($proxy['user']) ? urldecode($proxy['user']) : null;
-            $proxy_pass = isset($proxy['pass']) ? urldecode($proxy['pass']) : null;
+        $proxy = new PEAR_Proxy($config);
 
-            if ($callback) {
-                call_user_func($callback, 'message', "Using HTTP proxy $host:$port");
-            }
+        if ($proxy->isProxyConfigured() && $callback) {
+            call_user_func($callback, 'message', "Using HTTP proxy $host:$port");
         }
 
         if (empty($port)) {
@@ -1605,87 +1596,30 @@ class PEAR_Downloader extends PEAR_Common
         }
 
         $scheme = (isset($info['scheme']) && $info['scheme'] == 'https') ? 'https' : 'http';
+        $secure = ($scheme == 'https');
 
-        if ($proxy_host != '') {
-            $fp = @fsockopen($proxy_host, $proxy_port, $errno, $errstr);
-            if (!$fp) {
-                if ($callback) {
-                    call_user_func($callback, 'connfailed', array($proxy_host, $proxy_port,
-                                                                  $errno, $errstr));
-                }
-                return PEAR::raiseError("Connection to `$proxy_host:$proxy_port' failed: $errstr", $errno);
+        $fp = $proxy->openSocket($host, $port, $secure);
+        if (PEAR::isError($fp)) {
+            if ($callback) {
+                $errno = $fp->getCode();
+                $errstr = $fp->getMessage();
+                call_user_func($callback, 'connfailed', array($host, $port,
+                                                              $errno, $errstr));
             }
-
-            /* HTTPS is to be used and we have a proxy, use CONNECT verb */
-            if ($scheme === 'https') {
-                fwrite($fp, "CONNECT $host:$port HTTP/1.1\r\n");
-                fwrite($fp, "Host: $host:$port\r\n\r\n");
-
-                while ($line = trim(fgets($fp, 1024))) {
-                    if (preg_match('|^HTTP/1.[01] ([0-9]{3}) |', $line, $matches)) {
-                        $code = (int)$matches[1];
-
-                        /* as per RFC 2817 */
-                        if ($code < 200 || $code >= 300) {
-                            return PEAR::raiseError("Establishing a CONNECT tunnel through $proxy_host:$proxy_port failed with response code $code");
-                        }
-                    }
-                }
-
-                // connection was successful -- establish SSL through
-                // the tunnel
-                $crypto_method = STREAM_CRYPTO_METHOD_TLS_CLIENT;
-
-                if (defined('STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT')) {
-                    $crypto_method |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
-                    $crypto_method |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
-                }
-
-                // set the correct hostname for working hostname
-                // verification
-                stream_context_set_option($fp, 'ssl', 'peer_name', $host);
-
-                // blocking socket needed for
-                // stream_socket_enable_crypto()
-                // see
-                // <http://php.net/manual/en/function.stream-socket-enable-crypto.php>
-                stream_set_blocking ($fp, true);
-                $crypto_res = stream_socket_enable_crypto($fp, true, $crypto_method);
-                if (!$crypto_res) {
-                    return PEAR::raiseError("Could not establish SSL connection through proxy $proxy_host:$proxy_port: $crypto_res");
-                }
-            }
-
-            if ($lastmodified === false || $lastmodified) {
-                $request  = "GET $url HTTP/1.1\r\n";
-                $request .= "Host: $host\r\n";
-            } else {
-                $request  = "GET $url HTTP/1.0\r\n";
-                $request .= "Host: $host\r\n";
-            }
-        } else {
-            $network_host = $host;
-            if (isset($info['scheme']) && $info['scheme'] == 'https') {
-                $network_host = 'ssl://' . $host;
-            }
-
-            $fp = @fsockopen($network_host, $port, $errno, $errstr);
-            if (!$fp) {
-                if ($callback) {
-                    call_user_func($callback, 'connfailed', array($host, $port,
-                                                                  $errno, $errstr));
-                }
-                return PEAR::raiseError("Connection to `$host:$port' failed: $errstr", $errno);
-            }
-
-            if ($lastmodified === false || $lastmodified) {
-                $request = "GET $path HTTP/1.1\r\n";
-                $request .= "Host: $host\r\n";
-            } else {
-                $request = "GET $path HTTP/1.0\r\n";
-                $request .= "Host: $host\r\n";
-            }
+            return $fp;
         }
+
+        $requestPath = $path;
+        if ($proxy->isProxyConfigured()) {
+            $requestPath = $url;
+        }
+
+        if ($lastmodified === false || $lastmodified) {
+            $request  = "GET $requestPath HTTP/1.1\r\n";
+        } else {
+            $request  = "GET $requestPath HTTP/1.0\r\n";
+        }
+        $request .= "Host: $host\r\n";
 
         $ifmodifiedsince = '';
         if (is_array($lastmodified)) {
@@ -1712,9 +1646,10 @@ class PEAR_Downloader extends PEAR_Common
             }
         }
 
-        if ($proxy_host != '' && $proxy_user != '') {
+        $proxyAuth = $proxy->getProxyAuth();
+        if ($proxyAuth) {
             $request .= 'Proxy-Authorization: Basic ' .
-                base64_encode($proxy_user . ':' . $proxy_pass) . "\r\n";
+                $proxyAuth . "\r\n";
         }
 
         if ($accept) {

--- a/PEAR/Proxy.php
+++ b/PEAR/Proxy.php
@@ -75,7 +75,7 @@ class PEAR_Proxy
 
                 /* as per RFC 2817 */
                 if ($code < 200 || $code >= 300) {
-                    return PEAR::raiseError("Establishing a CONNECT tunnel through $proxy_host:$proxy_port failed with response code $code");
+                    return PEAR::raiseError("Establishing a CONNECT tunnel through proxy failed with response code $code");
                 }
             }
         }

--- a/PEAR/Proxy.php
+++ b/PEAR/Proxy.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * PEAR_Proxy
+ *
+ * HTTP Proxy handling 
+ *
+ * @category   pear
+ * @package    PEAR
+ * @author     Nico Boehr 
+ * @copyright  1997-2009 The Authors
+ * @license    http://opensource.org/licenses/bsd-license.php New BSD License
+ * @link       http://pear.php.net/package/PEAR
+ */
+
+class PEAR_Proxy
+{
+    var $config = null;
+
+    /**
+     * @access private
+     */
+    var $proxy_host;
+    /**
+     * @access private
+     */
+    var $proxy_port;
+    /**
+     * @access private
+     */
+    var $proxy_user;
+    /**
+     * @access private
+     */
+    var $proxy_pass;
+    /**
+     * @access private
+     */
+    var $proxy_schema;
+
+    function __construct($config = null)
+    {
+        $this->config = $config;
+        $this->_parseProxyInfo();
+    }
+
+    /**
+     * @access private
+     */
+    function _parseProxyInfo()
+    {
+        $this->proxy_host = $this->proxy_port = $this->proxy_user = $this->proxy_pass = '';
+        if ($this->config->get('http_proxy')&&
+              $proxy = parse_url($this->config->get('http_proxy'))
+        ) {
+            $this->proxy_host = isset($proxy['host']) ? $proxy['host'] : null;
+
+            $this->proxy_port   = isset($proxy['port']) ? $proxy['port'] : 8080;
+            $this->proxy_user   = isset($proxy['user']) ? urldecode($proxy['user']) : null;
+            $this->proxy_pass   = isset($proxy['pass']) ? urldecode($proxy['pass']) : null;
+            $this->proxy_schema = (isset($proxy['scheme']) && $proxy['scheme'] == 'https') ? 'https' : 'http';
+        }
+    }
+
+    /**
+     * @access private
+     */
+    function _httpConnect($fp, $host, $port)
+    {
+        fwrite($fp, "CONNECT $host:$port HTTP/1.1\r\n");
+        fwrite($fp, "Host: $host:$port\r\n\r\n");
+
+        while ($line = trim(fgets($fp, 1024))) {
+            if (preg_match('|^HTTP/1.[01] ([0-9]{3}) |', $line, $matches)) {
+                $code = (int)$matches[1];
+
+                /* as per RFC 2817 */
+                if ($code < 200 || $code >= 300) {
+                    return PEAR::raiseError("Establishing a CONNECT tunnel through $proxy_host:$proxy_port failed with response code $code");
+                }
+            }
+        }
+
+        // connection was successful -- establish SSL through
+        // the tunnel
+        $crypto_method = STREAM_CRYPTO_METHOD_TLS_CLIENT;
+
+        if (defined('STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT')) {
+            $crypto_method |= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+            $crypto_method |= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+        }
+
+        // set the correct hostname for working hostname
+        // verification
+        stream_context_set_option($fp, 'ssl', 'peer_name', $host);
+
+        // blocking socket needed for
+        // stream_socket_enable_crypto()
+        // see
+        // <http://php.net/manual/en/function.stream-socket-enable-crypto.php>
+        stream_set_blocking ($fp, true);
+        $crypto_res = stream_socket_enable_crypto($fp, true, $crypto_method);
+        if (!$crypto_res) {
+            return PEAR::raiseError("Could not establish SSL connection through proxy $proxy_host:$proxy_port: $crypto_res");
+        }
+
+        return true;
+    }
+
+    /**
+     * get the authorization information for the proxy, encoded to be
+     * passed in the Proxy-Authentication HTTP header.
+     * @return null|string the encoded authentication information if a
+     *                     proxy and authentication is configured, null 
+     *                     otherwise.
+     */
+    function getProxyAuth()
+    {
+        if ($this->isProxyConfigured() && $this->proxy_user != '') {
+            return base64_encode($this->proxy_user . ':' . $this->proxy_pass);
+        }
+        return null;
+    }
+
+    function getProxyUser()
+    {
+        return $this->proxy_user;
+    }
+
+    /**
+     * Check if we are configured to use a proxy.
+     *
+     * @return boolean true if we are configured to use a proxy, false
+     *                 otherwise.
+     * @access public
+     */
+    function isProxyConfigured()
+    {
+        return $this->proxy_host != '';
+    }
+
+    /**
+     * Open a socket to a remote server, possibly involving a HTTP
+     * proxy.
+     *
+     * If an HTTP proxy has been configured (http_proxy PEAR_Config
+     * setting), the proxy will be used.
+     *
+     * @param string $host    the host to connect to
+     * @param string $port    the port to connect to
+     * @param boolean $secure if true, establish a secure connection
+     *                        using TLS.
+     * @access public
+     */
+    function openSocket($host, $port, $secure = false)
+    {
+        if ($this->isProxyConfigured()) {
+            $fp = @fsockopen(
+                $this->proxy_host, $this->proxy_port, 
+                $errno, $errstr, 15
+            );
+
+            if (!$fp) {
+                return PEAR::raiseError("Connection to `$proxy_host:$proxy_port' failed: $errstr", -9276);
+            }
+
+            /* HTTPS is to be used and we have a proxy, use CONNECT verb */
+            if ($secure) {
+                $res = $this->_httpConnect($fp, $host, $port);
+
+                if (PEAR::isError($res)) {
+                    return $res;
+                }
+            }
+        } else {
+            if ($secure) {
+                $host = 'ssl://' . $host;
+            }
+
+            $fp = @fsockopen($host, $port, $errno, $errstr);
+            if (!$fp) {
+                return PEAR::raiseError("Connection to `$host:$port' failed: $errstr", $errno);
+            }
+        }
+
+        return $fp;
+    }
+}

--- a/package2.xml
+++ b/package2.xml
@@ -316,6 +316,9 @@
    <file name="PEAR/Packager.php" role="php">
     <tasks:replace from="@package_version@" to="version" type="package-info" />
    </file>
+   <file name="PEAR/Proxy.php" role="php">
+    <tasks:replace from="@package_version@" to="version" type="package-info" />
+   </file>
    <file name="PEAR/Registry.php" role="php">
     <tasks:replace from="@package_version@" to="version" type="package-info" />
    </file>


### PR DESCRIPTION
At the moment, we handle proxy requests for HTTPS URLs (almost) the same
as regular non-encrypted HTTP requests. This means that we send a line
similar to this to the proxy:
    GET https://pear.horde.org HTTP/1.1

Many proxies do not handle proxy requests when they contain a HTTPS URL
(for example, Squid) and fail e.g. with a 501 Not Implemented error.

The proper way to make these requests is through the CONNECT verb.

This not only solves the issues with proxies that do not handle the
aforementioned GET requests with HTTPS URLs, but also increses security,
as we can do the SSL certificate validation by ourselves and do not have
to trust the proxy.

Additionally, we no longer speak HTTPS with the proxy in case we request
a HTTPS URL as it is simply no longer needed.

This patch improves upon PR #51.
