### PR TITLE
Fixed deprecated HttpRequest::setRawPostData()

### DIFF
--- a/tests/PEAR_Command_Pickle/pickle/packagefiles/http/docs/examples/KISS_XMLRPC_Client.php
+++ b/tests/PEAR_Command_Pickle/pickle/packagefiles/http/docs/examples/KISS_XMLRPC_Client.php
@@ -26,7 +26,7 @@ class XmlRpcClient
 		if ($this->namespace) {
 			$method = $this->namespace .'.'. $method;
 		}
-		$this->request->setRawPostData(xmlrpc_encode_request($method, $params));
+		$this->request->setBody(xmlrpc_encode_request($method, $params));
 		$response = $this->request->send();
 		if ($response->getResponseCode() != 200) {
 			throw new Exception($response->getBody(), $response->getResponseCode());
@@ -39,5 +39,3 @@ class XmlRpcClient
 		return $this->request->getHistory();
 	}
 }
-
-?>


### PR DESCRIPTION
Fixed deprecatedHttpRequest::setRawPostData(). HttpRequest::setBody() should be used instead.