### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,9 @@
         "pear/pear_frontend_gtk": "For GTK support",
         "pear/pear_frontend_web": "For Web support"
     },
+    "provide": {
+        "pear/pear-core-minimal": "*"
+    },
     "require-dev": {
         "phpunit/phpunit": "*"
     }


### PR DESCRIPTION
Both pear-core and pear-core-minimal may be considered to be installed via packagist since there are packages requiring any of them (`pear/archive_tar` and `pear/xml_util` want `pear/pear-core-minimal` yet other packages want `pear/pear`). 

In this case there's a conflict since both `pear/pear-core-minimal` and  `pear/pear` define class `PEAR` and related functions.

    PHP Fatal error:  Cannot redeclare _PEAR_call_destructors() (previously declared in 
    vendor/pear/pear/PEAR.php:742) in vendor/pear/pear-core-minimal/src/PEAR.php on line 815

If `pear/pear` would provide  `pear/pear-core-minimal`, then there won't be a need to install a conflicting package.

First reported by @plutonio21 at pear/pear-core-minimal#4


