### PR TITLE
spelling fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - pear list
   - pear install --force PEAR-*.tgz
   - pear list
-  - pear upgrade structures_graph xml_util
+  - pear upgrade --force structures_graph xml_util
   - pear list
   - pear install --force php_archive
   - pear list

--- a/PEAR.php
+++ b/PEAR.php
@@ -450,7 +450,7 @@ class PEAR
     }
 
     /**
-     * This method deletes all occurences of the specified element from
+     * This method deletes all occurrences of the specified element from
      * the expected error codes stack.
      *
      * @param  mixed $error_code error code that should be deleted

--- a/PEAR/Command/Remote.php
+++ b/PEAR/Command/Remote.php
@@ -589,7 +589,7 @@ parameter.
 
         // eliminate error messages for preferred_state-related errors
         /* TODO: Should be an option, but until now download does respect
-           prefered state */
+           preferred state */
         /* $options['ignorepreferred_state'] = 1; */
         // eliminate error messages for preferred_state-related errors
 

--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -167,7 +167,7 @@ class PEAR_Downloader extends PEAR_Common
         }
         $this->ui = &$ui;
         if (!$this->_preferredState) {
-            // don't inadvertantly use a non-set preferred_state
+            // don't inadvertently use a non-set preferred_state
             $this->_preferredState = null;
         }
 
@@ -786,7 +786,7 @@ class PEAR_Downloader extends PEAR_Common
         $this->config->set($key, $value, $layer, $channel);
         $this->_preferredState = $this->config->get('preferred_state', null, $channel);
         if (!$this->_preferredState) {
-            // don't inadvertantly use a non-set preferred_state
+            // don't inadvertently use a non-set preferred_state
             $this->_preferredState = null;
         }
     }

--- a/PEAR/PackageFile.php
+++ b/PEAR/PackageFile.php
@@ -289,7 +289,7 @@ class PEAR_PackageFile
     }
 
     /**
-     * Create a PEAR_PackageFile_v* from a compresed Tar or Tgz file.
+     * Create a PEAR_PackageFile_v* from a compressed Tar or Tgz file.
      * @access  public
      * @param string contents of package.xml file
      * @param int package state (one of PEAR_VALIDATE_* constants)

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -906,7 +906,7 @@ class PEAR_Registry extends PEAR
     }
 
     /**
-     * Determine whether a mirror exists within the deafult channel in the registry
+     * Determine whether a mirror exists within the default channel in the registry
      *
      * @param string Channel name
      * @param string Mirror name

--- a/System.php
+++ b/System.php
@@ -22,7 +22,7 @@ require_once 'Console/Getopt.php';
 $GLOBALS['_System_temp_files'] = array();
 
 /**
-* System offers cross plattform compatible system functions
+* System offers cross platform compatible system functions
 *
 * Static functions for different operations. Should work under
 * Unix and Windows. The names and usage has been taken from its respectively
@@ -547,7 +547,7 @@ class System
      * System::find("$dir -name *.php -name *.htm*");
      * System::find("$dir -maxdepth 1");
      *
-     * Params implmented:
+     * Params implemented:
      * $dir            -> Start the search at this directory
      * -type d         -> return only directories
      * -type f         -> return only files

--- a/docs/Archive_Tar.txt
+++ b/docs/Archive_Tar.txt
@@ -362,7 +362,7 @@ Description :
   file/directory present in the archive. 
   The array is not sorted, so it show the position of the file in the
   archive. 
-  The file information are :
+  The file informations are :
     $file[filename] : Name and path of the file/dir.
     $file[mode] : File permissions (result of fileperms())
     $file[uid] : user id

--- a/docs/Archive_Tar.txt
+++ b/docs/Archive_Tar.txt
@@ -362,7 +362,7 @@ Description :
   file/directory present in the archive. 
   The array is not sorted, so it show the position of the file in the
   archive. 
-  The file informations are :
+  The file information are :
     $file[filename] : Name and path of the file/dir.
     $file[mode] : File permissions (result of fileperms())
     $file[uid] : user id

--- a/tests/PEAR/pear1.phpt
+++ b/tests/PEAR/pear1.phpt
@@ -41,7 +41,7 @@ class Other extends Pear {
     function _Other() {
         // $a was modified but here misteriously returns to be
         // the original value. That makes the destructor useless
-        // The correct value for $a in the destructor shoud be "new value"
+        // The correct value for $a in the destructor should be "new value"
         echo "#bug 14744# Other class destructor: other->a == '" . $this->a ."'\n";
     }
 }

--- a/tests/PEAR_Command_Install/bundle/packages/Archive_Tar/docs/Archive_Tar.txt
+++ b/tests/PEAR_Command_Install/bundle/packages/Archive_Tar/docs/Archive_Tar.txt
@@ -399,7 +399,7 @@ Description :
   file/directory present in the archive. 
   The array is not sorted, so it show the position of the file in the
   archive. 
-  The file information are :
+  The file informations are :
     $file[filename] : Name and path of the file/dir.
     $file[mode] : File permissions (result of fileperms())
     $file[uid] : user id

--- a/tests/PEAR_Command_Install/bundle/packages/Archive_Tar/docs/Archive_Tar.txt
+++ b/tests/PEAR_Command_Install/bundle/packages/Archive_Tar/docs/Archive_Tar.txt
@@ -399,7 +399,7 @@ Description :
   file/directory present in the archive. 
   The array is not sorted, so it show the position of the file in the
   archive. 
-  The file informations are :
+  The file information are :
     $file[filename] : Name and path of the file/dir.
     $file[mode] : File permissions (result of fileperms())
     $file[uid] : user id

--- a/tests/PEAR_Command_Package/convert/packagefiles/bug11703.xml
+++ b/tests/PEAR_Command_Package/convert/packagefiles/bug11703.xml
@@ -233,7 +233,7 @@ Currently, the following decorators are provided:
 - added Translation2_Admin::updateLang()
 - fixed bug #2890: getLang() raised a NOTICE if setLang() was not called before
 - fixed bug #2972: CacheLiteFunction decorator not handling
-  parameter subtitution as expected
+  parameter substitution as expected
 - updated dataobjectsimple container (alank)
 - some internal minor fixes and tweaks
       </notes>

--- a/tests/PEAR_Command_Package/convert/test_bug11703.phpt
+++ b/tests/PEAR_Command_Package/convert/test_bug11703.phpt
@@ -372,7 +372,7 @@ Currently, the following decorators are provided:
 - added Translation2_Admin::updateLang()
 - fixed bug #2890: getLang() raised a NOTICE if setLang() was not called before
 - fixed bug #2972: CacheLiteFunction decorator not handling
-  parameter subtitution as expected
+  parameter substitution as expected
 - updated dataobjectsimple container (alank)
 - some internal minor fixes and tweaks
    </notes>

--- a/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Database.php
+++ b/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Database.php
@@ -1188,7 +1188,7 @@ class DB_Table_Database extends DB_Table_Base
      *     $dir = $this->_table_subclass_path;
      *     require_once $dir . '/' . $subclass . '.php';
      * </code>
-     * See the getTableSubclass() docblock for a discusion of capitalization
+     * See the getTableSubclass() docblock for a discussion of capitalization
      * conventions in PHP 4 and 5 for subclass file names. 
      * 
      * @param string $path path to directory containing class definitions

--- a/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Generator.php
+++ b/tests/PEAR_Command_Package/package/packagefiles/DB_Table/DB/Table/Generator.php
@@ -109,7 +109,7 @@ foreach ($GLOBALS['_DB_TABLE_GENERATOR']['default_error'] as $code => $message) 
  * Here $class_write_path should be the path (without a trailing 
  * separator) to a directory in which all of the code should be 
  * written. If this directory does not exist, it will be created. 
- * If the directory does already exist, exising files will not 
+ * If the directory does already exist, existing files will not 
  * be overwritten. If $class_write_path is not set (i.e., if this
  * line is omitted) all the code will be written to the current 
  * directory.  If ->generateDatabaseFile() is called, it must be 

--- a/tests/PEAR_Command_Package/package/packagefiles/DB_Table/tests/database/db1/define.php
+++ b/tests/PEAR_Command_Package/package/packagefiles/DB_Table/tests/database/db1/define.php
@@ -6,7 +6,7 @@
 // Database class
 require_once 'DB/Table/Database.php';
 
-// Create DB/MDB2 connnection
+// Create DB/MDB2 connection
 require 'config.php';
 
 // Construct DB_Table objects

--- a/tests/PEAR_Command_Pickle/pickle/packagefiles/http/docs/functions.html
+++ b/tests/PEAR_Command_Pickle/pickle/packagefiles/http/docs/functions.html
@@ -74,7 +74,7 @@ looking like: "Wed, 22 Dec 2004 11:34:47 GMT"</p>
 Returns the HTTP date as string.</p>
 <h2 id="http_build_uri">string http_build_uri(string url[, string proto[, string host[, int port]]])</h2>
 <p>Build a complete URI according to the supplied parameters.</p>
-<p>If the url is already abolute but a different proto was supplied,<br />
+<p>If the url is already absolute but a different proto was supplied,<br />
 only the proto part of the URI will be updated.  If url has no<br />
 path specified, the path of the current REQUEST_URI will be taken.<br />
 The host will be taken either from the Host HTTP header of the client<br />
@@ -153,7 +153,7 @@ else FALSE.</p>
 <p>Expects a string parameter containing the ETag to compare.  Optionally<br />
 accepts a bool parameter, which, if set to true, will check the header<br />
 usually used to validate HTTP ranges.</p>
-<p>Retuns TRUE if ETag matches or the header contained the asterisk ("*"),<br />
+<p>Returns TRUE if ETag matches or the header contained the asterisk ("*"),<br />
 else FALSE.</p>
 <h2 id="http_cache_last_modified">bool http_cache_last_modified([int timestamp_or_expires]])</h2>
 <p>Attempts to cache the sent entity by its last modification date.</p>
@@ -206,7 +206,7 @@ You can use one of the following constants for convenience:<br />
 <p>Please see http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3<br />
 for which redirect response code to use in which situation.</p>
 <p>To be RFC compliant, "Redirecting to <a>URI</a>." will be displayed,<br />
-if the client doesn't redirect immediatly, and the request method was<br />
+if the client doesn't redirect immediately, and the request method was<br />
 another one than HEAD.</p>
 <p>Returns FALSE on failure, or *exits* on success.</p>
 <p>A log entry will be written to the redirect log, if the INI entry<br />
@@ -220,7 +220,7 @@ another one than HEAD.</p>
 <p>Returns TRUE on success, or FALSE on failure.</p>
 <h2 id="http_send_stream">bool http_send_stream(resource stream)</h2>
 <p>Sends an already opened stream with support for (multiple) range requests.</p>
-<p>Expects a resource parameter referncing the stream to read from.</p>
+<p>Expects a resource parameter referencing the stream to read from.</p>
 <p>Returns TRUE on success, or FALSE on failure.</p>
 <h2 id="http_chunked_decode">string http_chunked_decode(string encoded)</h2>
 <p>Decodes a string that was HTTP-chunked encoded.</p>
@@ -310,7 +310,7 @@ www-form-urlencoded. See http_get() for a full list of available options.</p>
 <p>Returns the HTTP response(s) as string on success, or FALSE on failure.</p>
 <h2 id="http_put_file">string http_put_file(string url, string file[, array options[, array &info]])</h2>
 <p>Performs an HTTP PUT request on the supplied url.</p>
-<p>Expects the second parameter to be a string referncing the file to upload.<br />
+<p>Expects the second parameter to be a string referencing the file to upload.<br />
 See http_get() for a full list of available options.</p>
 <p>Returns the HTTP response(s) as string on success, or FALSE on failure.</p>
 <h2 id="http_put_stream">string http_put_stream(string url, resource stream[, array options[, array &info]])</h2>
@@ -494,7 +494,7 @@ passed to HttpRequest::setOptions(). </p>
 <p>Destroys the HttpRequest object.</p>
 <h3 id="HttpRequest_setOptions">bool HttpRequest::setOptions([array options])</h3>
 <p>Set the request options to use.  See http_get() for a full list of available options.</p>
-<p>Accepts an array as optional parameters, wich values will overwrite the <br />
+<p>Accepts an array as optional parameters, which values will overwrite the <br />
 currently set request options.  If the parameter is empty or mitted,<br />
 the optoions of the HttpRequest object will be reset.</p>
 <p>Returns TRUE on success, or FALSE on failure.</p>
@@ -613,7 +613,7 @@ Affects only POST and custom requests.</p>
 <p>Add a file to the POST request, leaving prefiously set files unchanged.<br />
 Affects only POST and custom requests. Cannot be used with raw post data.</p>
 <p>Expects a string parameter containing the form element name, and a string<br />
-paremeter containing the path to the file which should be uploaded.<br />
+parameter containing the path to the file which should be uploaded.<br />
 Additionally accepts an optional string parameter which could contain<br />
 the content type of the file.</p>
 <p>Returns TRUE on success, or FALSE if the content type seems not to contain a <br />
@@ -648,7 +648,7 @@ references the last received response.</p>
 <p>Accepts an string as optional parameter specifying a certain header to read.<br />
 If the parameter is empty or omitted all response headers will be returned.</p>
 <p>Returns either a string with the value of the header matching name if requested, <br />
-FALSE on failure, or an associative array containing all reponse headers.</p>
+FALSE on failure, or an associative array containing all response headers.</p>
 <p>If redirects were allowed and several responses were received, the data <br />
 references the last received response.</p>
 <h3 id="HttpRequest_getResponseCookie">array HttpRequest::getResponseCookie([string name])</h3>
@@ -728,7 +728,7 @@ HttpMalformedHeaderException, HttpEncodingException.</p>
 <p>Instantiate a new HttpRequestPool object.  An HttpRequestPool is<br />
 able to send several HttpRequests in parallel.</p>
 <p>WARNING: Don't attach/detach HttpRequest objects to the HttpRequestPool<br />
-object while you're using the implemented Interator interface. </p>
+object while you're using the implemented Iterator interface. </p>
 <p>Accepts virtual infinite optional parameters each referencing an<br />
 HttpRequest object.</p>
 <p>Throws HttpRequestException, HttpRequestPoolException, HttpInvalidParamException.</p>
@@ -924,7 +924,7 @@ which the data to send will be read.</p>
 <p>Returns the previously set path to the file to send as string.</p>
 <h3 id="HttpResponse_send">static bool HttpResponse::send([bool clean_ob = true])</h3>
 <p>Finally send the entity.</p>
-<p>Accepts an optional boolean parameter, specifying wheter the output<br />
+<p>Accepts an optional boolean parameter, specifying whether the output<br />
 buffers should be discarded prior sending.  A successful caching attempt<br />
 will cause a script termination, and write a log entry if the INI setting<br />
 http.cache_log is set.</p>

--- a/tests/PEAR_Command_Pickle/pickle/packagefiles/http/docs/http.ini
+++ b/tests/PEAR_Command_Pickle/pickle/packagefiles/http/docs/http.ini
@@ -5,7 +5,7 @@
 ; enable if you want to transform all errors to exceptions (PHP >= 5 only)
 http.only_exceptions = 0
 
-; the hashing algorithm with wich ETags are generated
+; the hashing algorithm with which ETags are generated
 ; you can use mhash constants if ext/mhash is enabled, or their 
 ; literal representation if ext/http was linked against libmhash
 ;http.etag_mode = HTTP_ETAG_MHASH_TIGER ; same as 7

--- a/tests/PEAR_Command_Pickle/pickle/packagefiles/http/http_functions.c
+++ b/tests/PEAR_Command_Pickle/pickle/packagefiles/http/http_functions.c
@@ -74,7 +74,7 @@ PHP_FUNCTION(http_date)
  *
  * Build a complete URI according to the supplied parameters.
  * 
- * If the url is already abolute but a different proto was supplied,
+ * If the url is already absolute but a different proto was supplied,
  * only the proto part of the URI will be updated.  If url has no
  * path specified, the path of the current REQUEST_URI will be taken.
  * The host will be taken either from the Host HTTP header of the client
@@ -392,7 +392,7 @@ PHP_FUNCTION(http_match_modified)
  * accepts a bool parameter, which, if set to true, will check the header
  * usually used to validate HTTP ranges.
  * 
- * Retuns TRUE if ETag matches or the header contained the asterisk ("*"),
+ * Returns TRUE if ETag matches or the header contained the asterisk ("*"),
  * else FALSE.
  */
 PHP_FUNCTION(http_match_etag)
@@ -566,7 +566,7 @@ PHP_FUNCTION(http_throttle)
  * for which redirect response code to use in which situation.
  *
  * To be RFC compliant, "Redirecting to <a>URI</a>." will be displayed,
- * if the client doesn't redirect immediatly, and the request method was
+ * if the client doesn't redirect immediately, and the request method was
  * another one than HEAD.
  * 
  * Returns FALSE on failure, or *exits* on success.
@@ -716,7 +716,7 @@ PHP_FUNCTION(http_send_file)
  *
  * Sends an already opened stream with support for (multiple) range requests.
  *
- * Expects a resource parameter referncing the stream to read from.
+ * Expects a resource parameter referencing the stream to read from.
  * 
  * Returns TRUE on success, or FALSE on failure.
  */
@@ -1150,7 +1150,7 @@ PHP_FUNCTION(http_post_fields)
  *
  * Performs an HTTP PUT request on the supplied url.
  * 
- * Expects the second parameter to be a string referncing the file to upload.
+ * Expects the second parameter to be a string referencing the file to upload.
  * See http_get() for a full list of available options.
  * 
  * Returns the HTTP response(s) as string on success, or FALSE on failure.

--- a/tests/PEAR_Command_Pickle/pickle/packagefiles/http/http_request_object.c
+++ b/tests/PEAR_Command_Pickle/pickle/packagefiles/http/http_request_object.c
@@ -768,7 +768,7 @@ PHP_METHOD(HttpRequest, __destruct)
  *
  * Set the request options to use.  See http_get() for a full list of available options.
  * 
- * Accepts an array as optional parameters, wich values will overwrite the 
+ * Accepts an array as optional parameters, which values will overwrite the 
  * currently set request options.  If the parameter is empty or mitted,
  * the optoions of the HttpRequest object will be reset.
  * 
@@ -1411,7 +1411,7 @@ PHP_METHOD(HttpRequest, getRawPostData)
  * Affects only POST and custom requests. Cannot be used with raw post data.
  * 
  * Expects a string parameter containing the form element name, and a string
- * paremeter containing the path to the file which should be uploaded.
+ * parameter containing the path to the file which should be uploaded.
  * Additionally accepts an optional string parameter which could contain
  * the content type of the file.
  * 
@@ -1591,7 +1591,7 @@ PHP_METHOD(HttpRequest, getResponseData)
  * If the parameter is empty or omitted all response headers will be returned.
  * 
  * Returns either a string with the value of the header matching name if requested, 
- * FALSE on failure, or an associative array containing all reponse headers.
+ * FALSE on failure, or an associative array containing all response headers.
  * 
  * If redirects were allowed and several responses were received, the data 
  * references the last received response.

--- a/tests/PEAR_Command_Pickle/pickle/packagefiles/http/http_requestpool_object.c
+++ b/tests/PEAR_Command_Pickle/pickle/packagefiles/http/http_requestpool_object.c
@@ -83,7 +83,7 @@ zend_function_entry http_requestpool_object_fe[] = {
 	HTTP_REQPOOL_ME(socketPerform, ZEND_ACC_PROTECTED)
 	HTTP_REQPOOL_ME(socketSelect, ZEND_ACC_PROTECTED)
 
-	/* implements Interator */
+	/* implements Iterator */
 	HTTP_REQPOOL_ME(valid, ZEND_ACC_PUBLIC)
 	HTTP_REQPOOL_ME(current, ZEND_ACC_PUBLIC)
 	HTTP_REQPOOL_ME(key, ZEND_ACC_PUBLIC)
@@ -159,7 +159,7 @@ static void _http_requestpool_object_llist2array(zval **req, zval *array TSRMLS_
  * able to send several HttpRequests in parallel.
  * 
  * WARNING: Don't attach/detach HttpRequest objects to the HttpRequestPool
- * object while you're using the implemented Interator interface. 
+ * object while you're using the implemented Iterator interface. 
  *
  * Accepts virtual infinite optional parameters each referencing an
  * HttpRequest object.

--- a/tests/PEAR_Command_Pickle/pickle/packagefiles/http/http_response_object.c
+++ b/tests/PEAR_Command_Pickle/pickle/packagefiles/http/http_response_object.c
@@ -1042,7 +1042,7 @@ PHP_METHOD(HttpResponse, getFile)
  *
  * Finally send the entity.
  * 
- * Accepts an optional boolean parameter, specifying wheter the output
+ * Accepts an optional boolean parameter, specifying whether the output
  * buffers should be discarded prior sending.  A successful caching attempt
  * will cause a script termination, and write a log entry if the INI setting
  * http.cache_log is set.

--- a/tests/PEAR_Command_Remote/list-all/test_rest_fail.phpt
+++ b/tests/PEAR_Command_Remote/list-all/test_rest_fail.phpt
@@ -771,7 +771,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/codegen/info.xml", '<?xml ve
  <c>pear.php.net</c>
  <ca xlink:href="/rest/c/Tools+and+Utilities">Tools and Utilities</ca>
  <l>PHP</l>
- <s>Tool to create Code generaters that operate on XML descriptions</s>
+ <s>Tool to create Code generators that operate on XML descriptions</s>
  <d>This is an \'abstract\' package, it provides the base
 framework for applications like CodeGen_PECL and
 CodeGen_MySqlUDF (not released yet).</d>
@@ -1821,7 +1821,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/db_sqlite_tools/info.xml", '
  <l>BSD License</l>
  <s>DB_Sqlite_Tools is an object oriented interface to effectively manage and backup Sqlite databases.</s>
  <d>DB_Sqlite_Tools is an object oriented interface to effectively manage and backup Sqlite databases.It extends the existing functionality by providing a comprehensive solution for database backup, live
-  replication, export in XML format, performance optmization and other functionalities like the insertion and retrieval of encrypted data from an Sqlite database without any external extension.</d>
+  replication, export in XML format, performance optimization and other functionalities like the insertion and retrieval of encrypted data from an Sqlite database without any external extension.</d>
  <r xlink:href="/rest/r/db_sqlite_tools"/>
 </p>', 'text/xml');
 $pearweb->addRESTConfig("http://pear.php.net/rest/r/db_sqlite_tools/allreleases.xml", '<?xml version="1.0" encoding="iso-8859-1" ?>
@@ -1943,7 +1943,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/file_archive/info.xml", '<?x
  <ca xlink:href="/rest/c/File+Formats">File Formats</ca>
  <l>LGPL</l>
  <s>File_Archive will let you manipulate easily the tar, gz, tgz, bz2, tbz, zip, ar (or deb) files</s>
- <d>This library is strongly object oriented. It makes it very easy to use, writing simple code, yet the library is very powerfull.
+ <d>This library is strongly object oriented. It makes it very easy to use, writing simple code, yet the library is very powerful.
 It lets you easily read or generate tar, gz, tgz, bz2, tbz, zip, ar (or deb) archives to files, memory, mail or standard output.
 See http://poocl.la-grotte.org for a tutorial</d>
  <r xlink:href="/rest/r/file_archive"/>
@@ -1980,7 +1980,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/file_bittorrent/info.xml", '
  <l>PHP License</l>
  <s>Decode and Encode data in Bittorrent format</s>
  <d>This package consists of three classes which handles the encoding and decoding of data in Bittorrent format.
-    You can also extract useful informations from .torrent files, create .torrent files and query the torrent\'s scrape page to get its statistics.</d>
+    You can also extract useful information from .torrent files, create .torrent files and query the torrent\'s scrape page to get its statistics.</d>
  <r xlink:href="/rest/r/file_bittorrent"/>
 </p>', 'text/xml');
 $pearweb->addRESTConfig("http://pear.php.net/rest/r/file_bittorrent/allreleases.xml", '<?xml version="1.0" encoding="iso-8859-1" ?>
@@ -2011,7 +2011,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/file_dicom/info.xml", '<?xml
  <s>Package for reading and modifying DICOM files</s>
  <d>File_DICOM allows reading and modifying of DICOM files.
  DICOM stands for Digital Imaging and COmmunications in Medicine, and is a standard
- for creating, storing and transfering digital images (X-rays, tomography) and related information used in medicine.
+ for creating, storing and transferring digital images (X-rays, tomography) and related information used in medicine.
  This package in particular does not support the exchange/transfer of DICOM data, nor any network related functionality.
  More information on the DICOM standard can be found at: http://medical.nema.org/
  Please be aware that any use of the information produced by this package for diagnosing purposes is strongly discouraged by the author. See http://www.gnu.org/licenses/lgpl.html for more information.</d>
@@ -2793,7 +2793,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/html_javascript/info.xml", '
  <d>Provides two classes:
 HTML_Javascript for performing basic JS operations.
 HTML_Javascript_Convert for converting variables
-Allow output data to a file, to the standart output(print), or return</d>
+Allow output data to a file, to the standard output(print), or return</d>
  <r xlink:href="/rest/r/html_javascript"/>
 </p>', 'text/xml');
 $pearweb->addRESTConfig("http://pear.php.net/rest/r/html_javascript/allreleases.xml", '<?xml version="1.0" encoding="iso-8859-1" ?>
@@ -3303,7 +3303,7 @@ However, it still has a very simple set of goals.
    o By using object vars for a template rather than \'assign\', you
      can use phpdoc comments to list what variable you use.
 - Editable in WYSIWYG editors
-   o you can create full featured templates, that doesnt get broken every time you edit with
+   o you can create full featured templates, that doesn't get broken every time you edit with
      Dreamweaver(tm) or Mozilla editor
    o Uses namespaced attributes to add looping/conditionals
 - Extremely Fast,
@@ -3404,7 +3404,7 @@ Features :
 HTML_Template_ITX :
 With this class you get the full power of the phplib template class.
 You may have one file with blocks in it but you have as well one main file
-and multiple files one for each block. This is quite usefull when you have
+and multiple files one for each block. This is quite useful when you have
 user configurable websites. Using blocks not in the main template allows
 you to modify some parts of your layout easily.</d>
  <r xlink:href="/rest/r/html_template_it"/>
@@ -3889,7 +3889,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/http_upload/info.xml", '<?xm
  <c>pear.php.net</c>
  <ca xlink:href="/rest/c/HTTP">HTTP</ca>
  <l>LGPL</l>
- <s>Easy and secure managment of files submitted via HTML Forms</s>
+ <s>Easy and secure management of files submitted via HTML Forms</s>
  <d>This class provides an advanced file uploader system for file uploads made
 from html forms. Features:
  * Can handle from one file to multiple files.
@@ -4694,7 +4694,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/mail_imap/info.xml", '<?xml 
 Mail_IMAP can be used to retrieve the contents of a mailbox, whereas it may serve as the backend for a webmail application or mailing list manager.  Since Mail_IMAP is an abstracted object, it allows for complete customization of the UI for any application.
 
 ***NOTE***
-Mail_IMAPv2 is currently available. Mail_IMAPv2 is far more extensible, has far fewer bugs than Mail_IMAP 1, and is *not* backward compatible with Mail_IMAP 1. Any new developement should use Mail_IMAPv2.</d>
+Mail_IMAPv2 is currently available. Mail_IMAPv2 is far more extensible, has far fewer bugs than Mail_IMAP 1, and is *not* backward compatible with Mail_IMAP 1. Any new development should use Mail_IMAPv2.</d>
  <r xlink:href="/rest/r/mail_imap"/>
 </p>', 'text/xml');
 $pearweb->addRESTConfig("http://pear.php.net/rest/r/mail_imap/allreleases.xml", '<?xml version="1.0" encoding="iso-8859-1" ?>
@@ -4802,7 +4802,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/mail_queue/info.xml", '<?xml
  <ca xlink:href="/rest/c/Mail">Mail</ca>
  <l>PHP</l>
  <s>Class for put mails in queue and send them later in background.</s>
- <d>Class to handle mail queue managment.
+ <d>Class to handle mail queue management.
 Wrapper for PEAR::Mail and PEAR::DB (or PEAR::MDB/MDB2).
 It can load, save and send saved mails in background
 and also backup some mails.
@@ -4859,7 +4859,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/math_binaryutils/info.xml", 
  <ca xlink:href="/rest/c/Math">Math</ca>
  <l>LGPL</l>
  <s>Collection of helper methods for easy handling of binary data.</s>
- <d>Collection of helper methods for dealing with binary data (add, subtract, converting functions, endianess functions etc.).</d>
+ <d>Collection of helper methods for dealing with binary data (add, subtract, converting functions, endianness functions etc.).</d>
  <r xlink:href="/rest/r/math_binaryutils"/>
 </p>', 'text/xml');
 $pearweb->addRESTConfig("http://pear.php.net/rest/r/math_binaryutils/allreleases.xml", '<?xml version="1.0" encoding="iso-8859-1" ?>
@@ -4986,7 +4986,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/math_histogram/info.xml", '<
  <l>PHP</l>
  <s>Classes to calculate histogram distributions</s>
  <d>Classes to calculate histogram distributions and associated
-   statistics. Supports simple and cummulative histograms.
+   statistics. Supports simple and cumulative histograms.
    You can generate regular (2D) histograms, 3D, or 4D histograms
    Data must not have nulls.
 Requires Math_Stats.</d>
@@ -5145,7 +5145,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/math_stats/info.xml", '<?xml
  <s>Classes to calculate statistical parameters</s>
  <d>Package to calculate statistical parameters of numerical arrays
 of data. The data can be in a simple numerical array, or in a
-cummulative numerical array. A cummulative array, has the value
+cumulative numerical array. A cumulative array, has the value
 as the index and the number of repeats as the value for the
 array item, e.g. $data = array(3=&gt;4, 2.3=&gt;5, 1.25=&gt;6, 0.5=&gt;3).
 
@@ -7193,7 +7193,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/payment_dta/info.xml", '<?xm
  <ca xlink:href="/rest/c/Payment">Payment</ca>
  <l>BSD style</l>
  <s>Creates DTA files containing money transaction data (Germany).</s>
- <d>Payment_DTA provides functions to create DTA files used in Germany to exchange informations about money transactions with banks or online banking programs.</d>
+ <d>Payment_DTA provides functions to create DTA files used in Germany to exchange information about money transactions with banks or online banking programs.</d>
  <r xlink:href="/rest/r/payment_dta"/>
 </p>', 'text/xml');
 $pearweb->addRESTConfig("http://pear.php.net/rest/r/payment_dta/allreleases.xml", '<?xml version="1.0" encoding="iso-8859-1" ?>
@@ -7578,7 +7578,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/phpdoc/info.xml", '<?xml ver
  <ca xlink:href="/rest/c/PHP">PHP</ca>
  <l>PHP</l>
  <s>Tool to generate documentation from the source</s>
- <d>PHPDoc is an attemt to adopt Javadoc to the PHP world.</d>
+ <d>PHPDoc is an attempt to adopt Javadoc to the PHP world.</d>
  <r xlink:href="/rest/r/phpdoc"/>
 </p>', 'text/xml');
 $pearweb->addRESTConfig("http://pear.php.net/rest/r/phpdoc/allreleases.xml", '<?xml version="1.0" encoding="iso-8859-1" ?>
@@ -8602,7 +8602,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/structures_datagrid/info.xml
  <s>A tabular structure that contains a record set of data for paging and sorting purposes.</s>
  <d>This package offers a toolkit to render out a datagrid in HTML format as well as
 many other formats such as an XML Document, an Excel Spreadsheet, an XUL Document and more.
-It also offers paging and sorting functionallity to limit the data that is presented and processed.
+It also offers paging and sorting functionality to limit the data that is presented and processed.
 This concept is based on the .NET Framework DataGrid control and works very well with database and XML result sets.</d>
  <r xlink:href="/rest/r/structures_datagrid"/>
 </p>', 'text/xml');
@@ -9242,7 +9242,7 @@ Currently XML data can only be read from a file and accessed.
 The package offers a big number of methods to access and manipulate trees.
 For example methods like: getRoot, getChild[ren[Ids]], getParent[s[Ids]], getPath[ById] and many
 more.
-There are two ways of retreiving the data from the place where they are stored,
+There are two ways of retrieving the data from the place where they are stored,
 one is by reading the entire tree into the memory - the Memory way. The other
 is reading the tree nodes as needed (very useful in combination with huge trees
 and the nested set model).
@@ -9342,7 +9342,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/validate_at/info.xml", '<?xm
  <ca xlink:href="/rest/c/Validate">Validate</ca>
  <l>PHP</l>
  <s>Validation class for AT</s>
- <d>Package containes locale validation for AT such as:
+ <d>Package contains locale validation for AT such as:
  * SSN
  *  Postal Code</d>
  <r xlink:href="/rest/r/validate_at"/>
@@ -9378,7 +9378,7 @@ $pearweb->addRESTConfig("http://pear.php.net/rest/p/validate_be/info.xml", '<?xm
  <ca xlink:href="/rest/c/Validate">Validate</ca>
  <l>PHP</l>
  <s>Validation class for Belgium</s>
- <d>Package containes locale validation for Belgium such as:
+ <d>Package contains locale validation for Belgium such as:
  * Postal Code
  * Bank Account Number
  * Transfer message (transfer from an bank account to another)

--- a/tests/PEAR_Command_Remote/list-all/test_rest_fail.phpt
+++ b/tests/PEAR_Command_Remote/list-all/test_rest_fail.phpt
@@ -3303,7 +3303,7 @@ However, it still has a very simple set of goals.
    o By using object vars for a template rather than \'assign\', you
      can use phpdoc comments to list what variable you use.
 - Editable in WYSIWYG editors
-   o you can create full featured templates, that doesn't get broken every time you edit with
+   o you can create full featured templates, that doesn\'t get broken every time you edit with
      Dreamweaver(tm) or Mozilla editor
    o Uses namespaced attributes to add looping/conditionals
 - Extremely Fast,

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/btree.c
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/btree.c
@@ -101,7 +101,7 @@ typedef struct FreelistInfo FreelistInfo;
 ** This routine rounds up a number of bytes to the next multiple of 4.
 **
 ** This might need to change for computer architectures that require
-** and 8-byte alignment boundry for structures.
+** and 8-byte alignment boundary for structures.
 */
 #define ROUNDUP(X)  ((X+3) & ~3)
 
@@ -250,7 +250,7 @@ struct Cell {
 /*
 ** Free space on a page is remembered using a linked list of the FreeBlk
 ** structures.  Space on a database page is allocated in increments of
-** at least 4 bytes and is always aligned to a 4-byte boundry.  The
+** at least 4 bytes and is always aligned to a 4-byte boundary.  The
 ** linked list of FreeBlks is always kept in order by address.
 */
 struct FreeBlk {
@@ -1228,7 +1228,7 @@ static int getPayload(BtCursor *pCur, int offset, int amt, char *zBuf){
 
 /*
 ** Read part of the key associated with cursor pCur.  A maximum
-** of "amt" bytes will be transfered into zBuf[].  The transfer
+** of "amt" bytes will be transferred into zBuf[].  The transfer
 ** begins at "offset".  The number of bytes actually read is
 ** returned. 
 **
@@ -1278,7 +1278,7 @@ static int fileBtreeDataSize(BtCursor *pCur, int *pSize){
 
 /*
 ** Read part of the data associated with cursor pCur.  A maximum
-** of "amt" bytes will be transfered into zBuf[].  The transfer
+** of "amt" bytes will be transferred into zBuf[].  The transfer
 ** begins at "offset".  The number of bytes actually read is
 ** returned.  The amount returned will be smaller than the
 ** amount requested if there are not enough bytes in the data
@@ -3536,7 +3536,7 @@ static int fileBtreeCopyFile(Btree *pBtTo, Btree *pBtFrom){
 /*
 ** The following tables contain pointers to all of the interface
 ** routines for this implementation of the B*Tree backend.  To
-** substitute a different implemention of the backend, one has merely
+** substitute a different implementation of the backend, one has merely
 ** to provide pointers to alternative functions in similar tables.
 */
 static BtOps sqliteBtreeOps = {

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/date.c
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/date.c
@@ -28,7 +28,7 @@
 ** 1970-01-01 00:00:00 is JD 2440587.5
 ** 2000-01-01 00:00:00 is JD 2451544.5
 **
-** This implemention requires years to be expressed as a 4-digit number
+** This implementation requires years to be expressed as a 4-digit number
 ** which means that only dates between 0000-01-01 and 9999-12-31 can
 ** be represented, even though julian day numbers allow a much wider
 ** range of dates.
@@ -504,7 +504,7 @@ static int parseModifier(const char *zMod, DateTime *p){
       /*
       **    weekday N
       **
-      ** Move the date to the same time on the next occurrance of
+      ** Move the date to the same time on the next occurrence of
       ** weekday N where 0==Sunday, 1==Monday, and so forth.  If the
       ** date is already on the appropriate weekday, this is a no-op.
       */

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/hash.h
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/hash.h
@@ -9,7 +9,7 @@
 **    May you share freely, never taking more than you give.
 **
 *************************************************************************
-** This is the header file for the generic hash-table implemenation
+** This is the header file for the generic hash-table implementation
 ** used in SQLite.
 **
 ** $Id$

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/main.c
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/main.c
@@ -723,7 +723,7 @@ int sqlite_compile(
   sParse.db = db;
   sqliteRunParser(&sParse, zSql, pzErrMsg);
   if( db->xTrace && !db->init.busy ){
-    /* Trace only the statment that was compiled.
+    /* Trace only the statement that was compiled.
     ** Make a copy of that part of the SQL string since zSQL is const
     ** and we must pass a zero terminated string to the trace function
     ** The copy is unnecessary if the tail pointer is pointing at the

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/pager.c
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/pager.c
@@ -1842,7 +1842,7 @@ int sqlitepager_write(void *pData){
 
   /* If the checkpoint journal is open and the page is not in it,
   ** then write the current page to the checkpoint journal.  Note that
-  ** the checkpoint journal always uses the simplier format 2 that lacks
+  ** the checkpoint journal always uses the simpler format 2 that lacks
   ** checksums.  The header is also omitted from the checkpoint journal.
   */
   if( pPager->ckptInUse && !pPg->inCkpt && (int)pPg->pgno<=pPager->ckptSize ){

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/parse.c
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/parse.c
@@ -609,7 +609,7 @@ static YYACTIONTYPE yy_default[] = {
 ** 
 **      %fallback ID X Y Z.
 **
-** appears in the grammer, then ID becomes a fallback token for X, Y,
+** appears in the grammar, then ID becomes a fallback token for X, Y,
 ** and Z.  Whenever one of the tokens X, Y, or Z is input to the parser
 ** but it does not parse, the type of the token is changed to ID and
 ** the parse is retried before an error is thrown.

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/parse.y
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/parse.y
@@ -128,7 +128,7 @@ id(A) ::= ID(X).         {A = X;}
   TEMP TRIGGER VACUUM VIEW.
 
 // Define operator precedence early so that this is the first occurrence
-// of the operator tokens in the grammer.  Keeping the operators together
+// of the operator tokens in the grammar.  Keeping the operators together
 // causes them to be assigned integer values that are close together,
 // which keeps parser tables smaller.
 //
@@ -143,7 +143,7 @@ id(A) ::= ID(X).         {A = X;}
 %left CONCAT.
 %right UMINUS UPLUS BITNOT.
 
-// And "ids" is an identifer-or-string.
+// And "ids" is an identifier-or-string.
 //
 %type ids {Token}
 ids(A) ::= ID(X).        {A = X;}

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/select.c
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/select.c
@@ -2207,7 +2207,7 @@ int sqliteSelect(
   }
 
   /* Check to see if this is a subquery that can be "flattened" into its parent.
-  ** If flattening is a possiblity, do so and return immediately.  
+  ** If flattening is a possibility, do so and return immediately.  
   */
   if( pParent && pParentAgg &&
       flattenSubquery(pParse, pParent, parentTab, *pParentAgg, isAgg) ){

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/sqlite.h.in
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/sqlite.h.in
@@ -206,7 +206,7 @@ int sqlite_changes(sqlite*);
 
 /*
 ** This function returns the number of database rows that were changed
-** by the last INSERT, UPDATE, or DELETE statment executed by sqlite_exec(),
+** by the last INSERT, UPDATE, or DELETE statement executed by sqlite_exec(),
 ** or by the last VM to run to completion. The change count is not updated
 ** by SQL statements other than INSERT, UPDATE or DELETE.
 **
@@ -496,7 +496,7 @@ int sqlite_function_type(
 **
 ** The sqlite_set_result_string() function allocates a buffer to hold the
 ** result and returns a pointer to this buffer.  The calling routine
-** (that is, the implmentation of a user function) can alter the content
+** (that is, the implementation of a user function) can alter the content
 ** of this buffer if desired.
 */
 char *sqlite_set_result_string(sqlite_func*,const char*,int);

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/sqlite.w32.h
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/sqlite.w32.h
@@ -206,7 +206,7 @@ int sqlite_changes(sqlite*);
 
 /*
 ** This function returns the number of database rows that were changed
-** by the last INSERT, UPDATE, or DELETE statment executed by sqlite_exec(),
+** by the last INSERT, UPDATE, or DELETE statement executed by sqlite_exec(),
 ** or by the last VM to run to completion. The change count is not updated
 ** by SQL statements other than INSERT, UPDATE or DELETE.
 **
@@ -496,7 +496,7 @@ int sqlite_function_type(
 **
 ** The sqlite_set_result_string() function allocates a buffer to hold the
 ** result and returns a pointer to this buffer.  The calling routine
-** (that is, the implmentation of a user function) can alter the content
+** (that is, the implementation of a user function) can alter the content
 ** of this buffer if desired.
 */
 char *sqlite_set_result_string(sqlite_func*,const char*,int);

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/sqliteInt.h
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/sqliteInt.h
@@ -1051,7 +1051,7 @@ struct TriggerStep {
  * constructed. When coding nested triggers (triggers fired by other triggers)
  * each nested trigger stores its parent trigger's TriggerStack as the "pNext" 
  * pointer. Once the nested trigger has been coded, the pNext value is restored
- * to the pTriggerStack member of the Parse stucture and coding of the parent
+ * to the pTriggerStack member of the Parse structure and coding of the parent
  * trigger continues.
  *
  * Before a nested trigger is coded, the linked list pointed to by the 

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/tokenize.c
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/tokenize.c
@@ -535,7 +535,7 @@ abort_parse:
 **                 the end of a trigger definition.
 **
 **   (6) END       We've seen the ";END" of the ";END;" that occurs at the end
-**                 of a trigger difinition.
+**                 of a trigger definition.
 **
 ** Transitions between states above are determined by tokens extracted
 ** from the input.  The following tokens are significant:

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/util.c
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/util.c
@@ -431,7 +431,7 @@ void sqliteErrorMsg(Parse *pParse, const char *zFormat, ...){
 ** is a no-op.
 **
 ** 2002-Feb-14: This routine is extended to remove MS-Access style
-** brackets from around identifers.  For example:  "[a-b-c]" becomes
+** brackets from around identifiers.  For example:  "[a-b-c]" becomes
 ** "a-b-c".
 */
 void sqliteDequote(char *z){

--- a/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/vdbe.c
+++ b/tests/PEAR_Downloader/test_upgrade_pecl/libsqlite/src/vdbe.c
@@ -1954,7 +1954,7 @@ case OP_MakeRecord: {
 ** back in its place.
 **
 ** P3 is a string that is P1 characters long.  Each character is either
-** an 'n' or a 't' to indicates if the argument should be intepreted as
+** an 'n' or a 't' to indicates if the argument should be interpreted as
 ** numeric or text type.  The first character of P3 corresponds to the
 ** lowest element on the stack.  If P3 is NULL then all arguments are
 ** assumed to be of the numeric type.
@@ -1992,7 +1992,7 @@ case OP_MakeRecord: {
 ** back.  The first P1 entries that are popped are strings and the last
 ** entry (the lowest on the stack) is an integer record number.
 **
-** The converstion of the first P1 string entries occurs just like in
+** The conversion of the first P1 string entries occurs just like in
 ** MakeKey.  Each entry is separated from the others by a null.
 ** The entire concatenation is null-terminated.  The lowest entry
 ** in the stack is the first field and the top of the stack becomes the

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/btree.c
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/btree.c
@@ -101,7 +101,7 @@ typedef struct FreelistInfo FreelistInfo;
 ** This routine rounds up a number of bytes to the next multiple of 4.
 **
 ** This might need to change for computer architectures that require
-** and 8-byte alignment boundry for structures.
+** and 8-byte alignment boundary for structures.
 */
 #define ROUNDUP(X)  ((X+3) & ~3)
 
@@ -250,7 +250,7 @@ struct Cell {
 /*
 ** Free space on a page is remembered using a linked list of the FreeBlk
 ** structures.  Space on a database page is allocated in increments of
-** at least 4 bytes and is always aligned to a 4-byte boundry.  The
+** at least 4 bytes and is always aligned to a 4-byte boundary.  The
 ** linked list of FreeBlks is always kept in order by address.
 */
 struct FreeBlk {
@@ -1228,7 +1228,7 @@ static int getPayload(BtCursor *pCur, int offset, int amt, char *zBuf){
 
 /*
 ** Read part of the key associated with cursor pCur.  A maximum
-** of "amt" bytes will be transfered into zBuf[].  The transfer
+** of "amt" bytes will be transferred into zBuf[].  The transfer
 ** begins at "offset".  The number of bytes actually read is
 ** returned. 
 **
@@ -1278,7 +1278,7 @@ static int fileBtreeDataSize(BtCursor *pCur, int *pSize){
 
 /*
 ** Read part of the data associated with cursor pCur.  A maximum
-** of "amt" bytes will be transfered into zBuf[].  The transfer
+** of "amt" bytes will be transferred into zBuf[].  The transfer
 ** begins at "offset".  The number of bytes actually read is
 ** returned.  The amount returned will be smaller than the
 ** amount requested if there are not enough bytes in the data
@@ -3536,7 +3536,7 @@ static int fileBtreeCopyFile(Btree *pBtTo, Btree *pBtFrom){
 /*
 ** The following tables contain pointers to all of the interface
 ** routines for this implementation of the B*Tree backend.  To
-** substitute a different implemention of the backend, one has merely
+** substitute a different implementation of the backend, one has merely
 ** to provide pointers to alternative functions in similar tables.
 */
 static BtOps sqliteBtreeOps = {

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/date.c
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/date.c
@@ -28,7 +28,7 @@
 ** 1970-01-01 00:00:00 is JD 2440587.5
 ** 2000-01-01 00:00:00 is JD 2451544.5
 **
-** This implemention requires years to be expressed as a 4-digit number
+** This implementation requires years to be expressed as a 4-digit number
 ** which means that only dates between 0000-01-01 and 9999-12-31 can
 ** be represented, even though julian day numbers allow a much wider
 ** range of dates.
@@ -504,7 +504,7 @@ static int parseModifier(const char *zMod, DateTime *p){
       /*
       **    weekday N
       **
-      ** Move the date to the same time on the next occurrance of
+      ** Move the date to the same time on the next occurrence of
       ** weekday N where 0==Sunday, 1==Monday, and so forth.  If the
       ** date is already on the appropriate weekday, this is a no-op.
       */

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/hash.h
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/hash.h
@@ -9,7 +9,7 @@
 **    May you share freely, never taking more than you give.
 **
 *************************************************************************
-** This is the header file for the generic hash-table implemenation
+** This is the header file for the generic hash-table implementation
 ** used in SQLite.
 **
 ** $Id$

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/main.c
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/main.c
@@ -723,7 +723,7 @@ int sqlite_compile(
   sParse.db = db;
   sqliteRunParser(&sParse, zSql, pzErrMsg);
   if( db->xTrace && !db->init.busy ){
-    /* Trace only the statment that was compiled.
+    /* Trace only the statement that was compiled.
     ** Make a copy of that part of the SQL string since zSQL is const
     ** and we must pass a zero terminated string to the trace function
     ** The copy is unnecessary if the tail pointer is pointing at the

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/parse.c
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/parse.c
@@ -609,7 +609,7 @@ static YYACTIONTYPE yy_default[] = {
 ** 
 **      %fallback ID X Y Z.
 **
-** appears in the grammer, then ID becomes a fallback token for X, Y,
+** appears in the grammar, then ID becomes a fallback token for X, Y,
 ** and Z.  Whenever one of the tokens X, Y, or Z is input to the parser
 ** but it does not parse, the type of the token is changed to ID and
 ** the parse is retried before an error is thrown.

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/parse.y
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/parse.y
@@ -128,7 +128,7 @@ id(A) ::= ID(X).         {A = X;}
   TEMP TRIGGER VACUUM VIEW.
 
 // Define operator precedence early so that this is the first occurrence
-// of the operator tokens in the grammer.  Keeping the operators together
+// of the operator tokens in the grammar.  Keeping the operators together
 // causes them to be assigned integer values that are close together,
 // which keeps parser tables smaller.
 //
@@ -143,7 +143,7 @@ id(A) ::= ID(X).         {A = X;}
 %left CONCAT.
 %right UMINUS UPLUS BITNOT.
 
-// And "ids" is an identifer-or-string.
+// And "ids" is an identifier-or-string.
 //
 %type ids {Token}
 ids(A) ::= ID(X).        {A = X;}

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/select.c
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/select.c
@@ -2207,7 +2207,7 @@ int sqliteSelect(
   }
 
   /* Check to see if this is a subquery that can be "flattened" into its parent.
-  ** If flattening is a possiblity, do so and return immediately.  
+  ** If flattening is a possibility, do so and return immediately.  
   */
   if( pParent && pParentAgg &&
       flattenSubquery(pParse, pParent, parentTab, *pParentAgg, isAgg) ){

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/sqlite.h.in
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/sqlite.h.in
@@ -206,7 +206,7 @@ int sqlite_changes(sqlite*);
 
 /*
 ** This function returns the number of database rows that were changed
-** by the last INSERT, UPDATE, or DELETE statment executed by sqlite_exec(),
+** by the last INSERT, UPDATE, or DELETE statement executed by sqlite_exec(),
 ** or by the last VM to run to completion. The change count is not updated
 ** by SQL statements other than INSERT, UPDATE or DELETE.
 **
@@ -496,7 +496,7 @@ int sqlite_function_type(
 **
 ** The sqlite_set_result_string() function allocates a buffer to hold the
 ** result and returns a pointer to this buffer.  The calling routine
-** (that is, the implmentation of a user function) can alter the content
+** (that is, the implementation of a user function) can alter the content
 ** of this buffer if desired.
 */
 char *sqlite_set_result_string(sqlite_func*,const char*,int);

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/sqlite.w32.h
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/sqlite.w32.h
@@ -206,7 +206,7 @@ int sqlite_changes(sqlite*);
 
 /*
 ** This function returns the number of database rows that were changed
-** by the last INSERT, UPDATE, or DELETE statment executed by sqlite_exec(),
+** by the last INSERT, UPDATE, or DELETE statement executed by sqlite_exec(),
 ** or by the last VM to run to completion. The change count is not updated
 ** by SQL statements other than INSERT, UPDATE or DELETE.
 **
@@ -496,7 +496,7 @@ int sqlite_function_type(
 **
 ** The sqlite_set_result_string() function allocates a buffer to hold the
 ** result and returns a pointer to this buffer.  The calling routine
-** (that is, the implmentation of a user function) can alter the content
+** (that is, the implementation of a user function) can alter the content
 ** of this buffer if desired.
 */
 char *sqlite_set_result_string(sqlite_func*,const char*,int);

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/sqliteInt.h
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/sqliteInt.h
@@ -1051,7 +1051,7 @@ struct TriggerStep {
  * constructed. When coding nested triggers (triggers fired by other triggers)
  * each nested trigger stores its parent trigger's TriggerStack as the "pNext" 
  * pointer. Once the nested trigger has been coded, the pNext value is restored
- * to the pTriggerStack member of the Parse stucture and coding of the parent
+ * to the pTriggerStack member of the Parse structure and coding of the parent
  * trigger continues.
  *
  * Before a nested trigger is coded, the linked list pointed to by the 

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/tokenize.c
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/tokenize.c
@@ -535,7 +535,7 @@ abort_parse:
 **                 the end of a trigger definition.
 **
 **   (6) END       We've seen the ";END" of the ";END;" that occurs at the end
-**                 of a trigger difinition.
+**                 of a trigger definition.
 **
 ** Transitions between states above are determined by tokens extracted
 ** from the input.  The following tokens are significant:

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/util.c
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/util.c
@@ -431,7 +431,7 @@ void sqliteErrorMsg(Parse *pParse, const char *zFormat, ...){
 ** is a no-op.
 **
 ** 2002-Feb-14: This routine is extended to remove MS-Access style
-** brackets from around identifers.  For example:  "[a-b-c]" becomes
+** brackets from around identifiers.  For example:  "[a-b-c]" becomes
 ** "a-b-c".
 */
 void sqliteDequote(char *z){

--- a/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/vdbe.c
+++ b/tests/PEAR_Installer/test_upgrade_pecl/libsqlite/src/vdbe.c
@@ -1954,7 +1954,7 @@ case OP_MakeRecord: {
 ** back in its place.
 **
 ** P3 is a string that is P1 characters long.  Each character is either
-** an 'n' or a 't' to indicates if the argument should be intepreted as
+** an 'n' or a 't' to indicates if the argument should be interpreted as
 ** numeric or text type.  The first character of P3 corresponds to the
 ** lowest element on the stack.  If P3 is NULL then all arguments are
 ** assumed to be of the numeric type.
@@ -1992,7 +1992,7 @@ case OP_MakeRecord: {
 ** back.  The first P1 entries that are popped are strings and the last
 ** entry (the lowest on the stack) is an integer record number.
 **
-** The converstion of the first P1 string entries occurs just like in
+** The conversion of the first P1 string entries occurs just like in
 ** MakeKey.  Each entry is separated from the others by a null.
 ** The entire concatenation is null-terminated.  The lowest entry
 ** in the stack is the first field and the top of the stack becomes the

--- a/tests/PEAR_PackageFile_v2_Validator/test_bug10733/package.xml
+++ b/tests/PEAR_PackageFile_v2_Validator/test_bug10733/package.xml
@@ -6,7 +6,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
  <name>PHP_Compat</name>
  <channel>pear.php.net</channel>
  <summary>Provides components to achieve PHP version independance</summary>
- <description>PHP_Compat provides drop-in functions and constants for compatibility with newer versions of PHP, enviroment emulation, and an API to allow for version independent authoring.</description>
+ <description>PHP_Compat provides drop-in functions and constants for compatibility with newer versions of PHP, environment emulation, and an API to allow for version independent authoring.</description>
  <lead>
   <name>Aidan Lister</name>
 


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.