### PR TITLE
fix #21188 Class 'PEAR_Proxy' not found

### DIFF
--- a/PEAR/REST.php
+++ b/PEAR/REST.php
@@ -18,6 +18,7 @@
  */
 require_once 'PEAR.php';
 require_once 'PEAR/XMLParser.php';
+require_once 'PEAR/Proxy.php';
 
 /**
  * Intelligently retrieve data, following hyperlinks if necessary, and re-directing


### PR DESCRIPTION
http://pear.php.net/bugs/bug.php?id=21188