### PR TITLE
fix #18102 pear install does not fail on error

### DIFF
--- a/PEAR/Command/Install.php
+++ b/PEAR/Command/Install.php
@@ -717,8 +717,7 @@ Run post-installation scripts in package <package>, if any exist.
                 $pkg = &$param->getPackageFile();
                 if ($info->getCode() != PEAR_INSTALLER_NOBINARY) {
                     if (!($info = $pkg->installBinary($this->installer))) {
-                        $this->ui->outputData('ERROR: ' .$oldinfo->getMessage());
-                        continue;
+                        return $this->raiseError('ERROR: ' .$oldinfo->getMessage());
                     }
 
                     // we just installed a different package than requested,


### PR DESCRIPTION
https://pear.php.net/bugs/bug.php?id=18102

This calls `raiseError` in the event of a package error, which causes an error code (1) to be returned to the shell.

All tests still pass, but admittedly, I don't know enough about pear internals to know if this change would have adverse side effects. It does have the potential to catch some build processes that may be silently failing currently (my comment on #18102 describes the situation that we ran into with the "zip" pecl package silently failing during our docker image builds).
