### PR TITLE
fix warning during pecl list-all

### DIFF
--- a/PEAR/PackageFile/v2.php
+++ b/PEAR/PackageFile/v2.php
@@ -1668,7 +1668,7 @@ class PEAR_PackageFile_v2
                     if ($dtype == 'pearinstaller' && $nopearinstaller) {
                         continue;
                     }
-                    if (!isset($deps[0])) {
+                    if ((is_array($deps) && !isset($deps[0])) || !is_array($deps)) {
                         $deps = array($deps);
                     }
                     foreach ($deps as $dep) {


### PR DESCRIPTION
```
$ pecl list-all

Warning: Invalid argument supplied for foreach() in PEAR/PackageFile/v2.php on line 1675
PHP Warning:  Invalid argument supplied for foreach() in /usr/share/pear/PEAR/PackageFile/v2.php on line 1675
All packages [Channel pecl.php.net]:
====================================
Package               Latest  Local
pecl/amfext           0.9.2                ActionScript Message Format extension
...
```

This happens when dep is a string (ie, "os" = "linux")
