### PR TITLE
PHP 7.2: Up recommended version of Archive_Tar (in package xml file).

### DIFF
--- a/package2.xml
+++ b/package2.xml
@@ -415,7 +415,7 @@
     <name>Archive_Tar</name>
     <channel>pear.php.net</channel>
     <min>1.4.0</min>
-    <recommended>1.4.2</recommended>
+    <recommended>1.4.3</recommended>
    </package>
    <package>
     <name>Structures_Graph</name>


### PR DESCRIPTION
One less thing to do... package2.xml now recommends 1.4.3 of Archive_Tar; thought it best to not adjust the min value.