### PR TITLE
Fix notice undefined variable metadata_dir

### DIFF
--- a/install-pear.php
+++ b/install-pear.php
@@ -247,7 +247,7 @@ $options['upgrade'] = true;
 $install_root = getenv('INSTALL_ROOT');
 if (!empty($install_root)) {
     $options['packagingroot'] = $install_root;
-    $reg = new PEAR_Registry($options['packagingroot'], false, false, $metadata_dir);
+    $reg = new PEAR_Registry($options['packagingroot'], false, false, $config->get('metadata_dir'));
 } else {
     $reg = $config->getRegistry('default');
 }


### PR DESCRIPTION
Hello, when compiling PHP from source the following notice appears:

```
Notice: Undefined variable: metadata_dir in phar://install-pear-nozlib.phar/index.php on line 255
```

If I'm correct, this patch should fix this. In case I've missed something, let me know. Thanks for checking it out or considering merging it.