### PR TITLE
Fix missing shared XML extension

### DIFF
--- a/scripts/pecl.sh
+++ b/scripts/pecl.sh
@@ -25,4 +25,11 @@ else
   fi
 fi
 
-exec $PHP -C -n -q $INCARG -d date.timezone=UTC -d output_buffering=1 -d variables_order=EGPCS -d safe_mode=0 -d register_argc_argv="On" $INCDIR/peclcmd.php "$@"
+# Find XML shared extension
+if test "x$($PHP -r 'print_r(extension_loaded("xml"));')" != "x"; then
+  if test "x$($PHP -n -r 'print_r(extension_loaded("xml"));')" = "x"; then
+    XMLFLAG="-d extension_dir="`$PHP -i | grep ^extension_dir | sed 's/.*=> //')`" -d extension=xml.so"
+  fi
+fi
+
+exec $PHP -C -n -q $INCARG -d date.timezone=UTC -d output_buffering=1 -d variables_order=EGPCS -d safe_mode=0 -d register_argc_argv="On" $XMLFLAG $INCDIR/peclcmd.php "$@"


### PR DESCRIPTION
Hello, this is a quick and probably a bit dirty patch to fix usage of PECL command line tool when PHP is built with shared XML extension. See [bug #75346](https://bugs.php.net/bug.php?id=75346) for more info. 

Thanks.