### PR TITLE
Fix PHP Warning: "continue" targeting switch is equivalent to "break"…

### DIFF
--- a/PEAR/PackageFile/v2/Validator.php
+++ b/PEAR/PackageFile/v2/Validator.php
@@ -1930,7 +1930,7 @@ class PEAR_PackageFile_v2_Validator
 
             switch ($token) {
                 case T_WHITESPACE :
-                    continue;
+                    break;
                 case ';':
                     if ($interface) {
                         $current_function = '';


### PR DESCRIPTION
… with 7.3


"continue 2" is another way to fix, but both are used in the various other cases, and this switch is last command in the loop