### PR TITLE
Prevent Unable to find the wrapper "channel" Warning

### DIFF
--- a/PEAR/Downloader/Package.php
+++ b/PEAR/Downloader/Package.php
@@ -1507,7 +1507,7 @@ class PEAR_Downloader_Package
     function _fromFile(&$param)
     {
         $saveparam = $param;
-        if (is_string($param)) {
+        if (is_string($param) && substr($param, 0, 10) !== 'channel://') {
             if (!@file_exists($param)) {
                 $test = explode('#', $param);
                 $group = array_pop($test);


### PR DESCRIPTION
@ashnazg php 7.0 emits 

> Unable to find the wrapper "channel"

as channel URL if passed to file functions

PEAR Version: 1.10.6