### PR TITLE
Add flags to PECL shell script for shared extensions

### DIFF
--- a/scripts/pecl.sh
+++ b/scripts/pecl.sh
@@ -25,4 +25,4 @@ else
   fi
 fi
 
-exec $PHP -C -n -q $INCARG -d date.timezone=UTC -d output_buffering=1 -d variables_order=EGPCS -d safe_mode=0 -d register_argc_argv="On" $INCDIR/peclcmd.php "$@"
+exec $PHP -C -q $INCARG -d date.timezone=UTC -d output_buffering=1 -d variables_order=EGPCS -d safe_mode=0 -d register_argc_argv="On" $INCDIR/peclcmd.php "$@"


### PR DESCRIPTION
Hello,

when PHP is using shared extensions (this goes mainly for the xml and openssl) the php CLI command needs to enable those separately for each required extension that PEAR and PECL are using.

To illustrate this more simply:

When PHP is build with something like 
```bash
./configure --with-openssl=shared --enable-xml=shared
```

Then pecl CLI script won't work ok... This patch fixes this.