### PR TITLE
Drop track_errors from options,

### DIFF
--- a/PEAR/RunTest.php
+++ b/PEAR/RunTest.php
@@ -64,7 +64,6 @@ class PEAR_RunTest
         'display_errors=1',
         'log_errors=0',
         'html_errors=0',
-        'track_errors=1',
         'report_memleaks=0',
         'report_zend_debug=0',
         'docref_root=',


### PR DESCRIPTION
as this may raise E_DEPRECATED warning and thus make test suite fail

BTW, PEAR still heavily rely on deprecated php_errmsg (ini_set being protected by silent operator)
so a long term solution seems needed.