### PR TITLE
Fix PHP 8 compatibility issues

### DIFF
--- a/PEAR/Command/Common.php
+++ b/PEAR/Command/Common.php
@@ -193,7 +193,7 @@ class PEAR_Command_Common extends PEAR
             $help = $this->commands[$command]['summary'];
         }
 
-        if (preg_match_all('/{config\s+([^\}]+)}/e', $help, $matches)) {
+        if (preg_match_all('/{config\s+([^\}]+)}/', $help, $matches)) {
             foreach($matches[0] as $k => $v) {
                 $help = preg_replace("/$v/", $config->get($matches[1][$k]), $help);
             }

--- a/PEAR/Command/Package.php
+++ b/PEAR/Command/Package.php
@@ -872,7 +872,6 @@ used for automated conversion or learning the format.
                 $deps = $info->getDependencies();
                 $reg = &$this->config->getRegistry();
                 if (is_array($deps)) {
-                    $d = new PEAR_Dependency2($this->config, array(), '');
                     $data = array(
                         'caption' => 'Dependencies for ' . $info->getPackage(),
                         'border' => true,
@@ -929,7 +928,7 @@ used for automated conversion or learning the format.
                                     if (isset($inf['conflicts'])) {
                                         $ver = 'conflicts';
                                     } else {
-                                        $ver = $d->_getExtraString($inf);
+                                        $ver = PEAR_Dependency2::_getExtraString($inf);
                                     }
 
                                     $data['data'][] = array($req, ucfirst($deptype), $name,

--- a/PEAR/Command/Registry.php
+++ b/PEAR/Command/Registry.php
@@ -585,8 +585,9 @@ installed package.'
                     case 'configure_options' : {
                         foreach ($info[$key] as $i => $p) {
                             $info[$key][$i] = array_map(null, array_keys($p), array_values($p));
-                            $info[$key][$i] = array_map(create_function('$a',
-                                'return join(" = ",$a);'), $info[$key][$i]);
+                            $info[$key][$i] = array_map(
+                                function($a) { return join(" = ", $a); },
+                                $info[$key][$i]);
                             $info[$key][$i] = implode(', ', $info[$key][$i]);
                         }
                         $info[$key] = implode("\n", $info[$key]);

--- a/PEAR/Common.php
+++ b/PEAR/Common.php
@@ -718,7 +718,7 @@ class PEAR_Common extends PEAR
      * @return mixed
      * @access public
      */
-    function analyzeSourceCode($file)
+    static function analyzeSourceCode($file)
     {
         if (!class_exists('PEAR_PackageFile_v2_Validator')) {
             require_once 'PEAR/PackageFile/v2/Validator.php';

--- a/PEAR/Common.php
+++ b/PEAR/Common.php
@@ -304,7 +304,7 @@ class PEAR_Common extends PEAR
      * @param boolean Determines whether to include $state in the list
      * @return false|array False if $state is not a valid release state
      */
-    function betterStates($state, $include = false)
+    static function betterStates($state, $include = false)
     {
         static $states = array('snapshot', 'devel', 'alpha', 'beta', 'stable');
         $i = array_search($state, $states);

--- a/PEAR/Config.php
+++ b/PEAR/Config.php
@@ -2086,7 +2086,7 @@ class PEAR_Config extends PEAR
         return $a;
     }
 
-    function _prependPath($path, $prepend)
+    static function _prependPath($path, $prepend)
     {
         if (strlen($prepend) > 0) {
             if (OS_WINDOWS && preg_match('/^[a-z]:/i', $path)) {

--- a/PEAR/Dependency2.php
+++ b/PEAR/Dependency2.php
@@ -1232,7 +1232,7 @@ class PEAR_Dependency2
             $dep['optional'] = 'no';
         }
 
-        list($newdep, $type) = $this->normalizeDep($dep);
+        list($newdep, $type) = self::normalizeDep($dep);
         if (!$newdep) {
             return $this->raiseError("Invalid Dependency");
         }
@@ -1246,7 +1246,7 @@ class PEAR_Dependency2
     /**
      * Convert a 1.0 dep into a 2.0 dep
      */
-    function normalizeDep($dep)
+    static function normalizeDep($dep)
     {
         $types = array(
             'pkg' => 'Package',

--- a/PEAR/Dependency2.php
+++ b/PEAR/Dependency2.php
@@ -1325,7 +1325,7 @@ class PEAR_Dependency2
      * @param  string Operator
      * @return string Sign equivalent
      */
-    function signOperator($operator)
+    static function signOperator($operator)
     {
         switch($operator) {
             case 'lt': return '<';

--- a/PEAR/Dependency2.php
+++ b/PEAR/Dependency2.php
@@ -110,7 +110,7 @@ class PEAR_Dependency2
         $this->_currentPackage = $package;
     }
 
-    function _getExtraString($dep)
+    static function _getExtraString($dep)
     {
         $extra = ' (';
         if (isset($dep['uri'])) {
@@ -337,7 +337,7 @@ class PEAR_Dependency2
         }
 
         $loaded = $this->extension_loaded($dep['name']);
-        $extra  = $this->_getExtraString($dep);
+        $extra  = self::_getExtraString($dep);
         if (isset($dep['exclude'])) {
             if (!is_array($dep['exclude'])) {
                 $dep['exclude'] = array($dep['exclude']);
@@ -486,7 +486,7 @@ class PEAR_Dependency2
         }
 
         $version = $this->phpversion();
-        $extra   = $this->_getExtraString($dep);
+        $extra   = self::_getExtraString($dep);
         if (isset($dep['exclude'])) {
             if (!is_array($dep['exclude'])) {
                 $dep['exclude'] = array($dep['exclude']);
@@ -546,7 +546,7 @@ class PEAR_Dependency2
     function validatePearinstallerDependency($dep)
     {
         $pearversion = $this->getPEARVersion();
-        $extra = $this->_getExtraString($dep);
+        $extra = self::_getExtraString($dep);
         if (isset($dep['exclude'])) {
             if (!is_array($dep['exclude'])) {
                 $dep['exclude'] = array($dep['exclude']);
@@ -700,7 +700,7 @@ class PEAR_Dependency2
             }
         }
 
-        $extra = $this->_getExtraString($dep);
+        $extra = self::_getExtraString($dep);
         if (isset($dep['exclude']) && !is_array($dep['exclude'])) {
             $dep['exclude'] = array($dep['exclude']);
         }
@@ -1098,7 +1098,7 @@ class PEAR_Dependency2
             return true;
         }
 
-        $extra = $this->_getExtraString($dep);
+        $extra = self::_getExtraString($dep);
         if (isset($dep['exclude']) && !is_array($dep['exclude'])) {
             $dep['exclude'] = array($dep['exclude']);
         }

--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -185,7 +185,7 @@ class PEAR_Downloader extends PEAR_Common
                 if (!count($unused)) {
                     continue;
                 }
-                $strtolower = create_function('$a','return strtolower($a);');
+                $strtolower = function($a) { return strtolower($a); };
                 array_walk($this->_installed[$key], $strtolower);
             }
         }

--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -1712,7 +1712,8 @@ class PEAR_Downloader extends PEAR_Common
         if (!$wp = @fopen($dest_file, 'wb')) {
             fclose($fp);
             if ($callback) {
-                call_user_func($callback, 'writefailed', array($dest_file, $php_errormsg));
+                call_user_func($callback, 'writefailed',
+                    array($dest_file, error_get_last()["message"]));
             }
             return PEAR::raiseError("could not open $dest_file for writing");
         }
@@ -1732,9 +1733,11 @@ class PEAR_Downloader extends PEAR_Common
             if (!@fwrite($wp, $data)) {
                 fclose($fp);
                 if ($callback) {
-                    call_user_func($callback, 'writefailed', array($dest_file, $php_errormsg));
+                    call_user_func($callback, 'writefailed',
+                        array($dest_file, error_get_last()["message"]));
                 }
-                return PEAR::raiseError("$dest_file: write failed ($php_errormsg)");
+                return PEAR::raiseError(
+                    "$dest_file: write failed (" . error_get_last()["message"] . ")");
             }
         }
 

--- a/PEAR/ErrorStack.php
+++ b/PEAR/ErrorStack.php
@@ -676,7 +676,7 @@ class PEAR_ErrorStack {
      * @return boolean
      * @since PEAR1.5.0a1
      */
-    function staticPop($package)
+    static function staticPop($package)
     {
         if ($package) {
             if (!isset($GLOBALS['_PEAR_ERRORSTACK_SINGLETON'][$package])) {

--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -323,8 +323,9 @@ class PEAR_Installer extends PEAR_Downloader
                 }
 
                 if (!@copy($orig_file, $dest_file)) {
-                    return $this->raiseError("failed to write $dest_file: $php_errormsg",
-                                             PEAR_INSTALLER_FAILED);
+                    return $this->raiseError(
+                        "failed to write $dest_file: " . error_get_last()["message"],
+                        PEAR_INSTALLER_FAILED);
                 }
 
                 $this->log(3, "+ cp $orig_file $dest_file");
@@ -399,13 +400,15 @@ class PEAR_Installer extends PEAR_Downloader
 
                 $wp = @fopen($dest_file, "wb");
                 if (!is_resource($wp)) {
-                    return $this->raiseError("failed to create $dest_file: $php_errormsg",
-                                             PEAR_INSTALLER_FAILED);
+                    return $this->raiseError(
+                        "failed to create $dest_file: " . error_get_last()["message"],
+                        PEAR_INSTALLER_FAILED);
                 }
 
                 if (@fwrite($wp, $contents) === false) {
-                    return $this->raiseError("failed writing to $dest_file: $php_errormsg",
-                                             PEAR_INSTALLER_FAILED);
+                    return $this->raiseError(
+                        "failed writing to $dest_file: " . error_get_last()["message"],
+                        PEAR_INSTALLER_FAILED);
                 }
 
                 fclose($wp);
@@ -452,7 +455,8 @@ class PEAR_Installer extends PEAR_Downloader
                     $this->addFileOperation("chmod", array($mode, $dest_file));
                     if (!@chmod($dest_file, $mode)) {
                         if (!isset($options['soft'])) {
-                            $this->log(0, "failed to change mode of $dest_file: $php_errormsg");
+                            $this->log(0, "failed to change mode of $dest_file: " .
+                                          error_get_last()["message"]);
                         }
                     }
                 }
@@ -562,8 +566,9 @@ class PEAR_Installer extends PEAR_Downloader
                 }
 
                 if (!@copy($orig_file, $dest_file)) {
-                    return $this->raiseError("failed to write $dest_file: $php_errormsg",
-                                             PEAR_INSTALLER_FAILED);
+                    return $this->raiseError(
+                        "failed to write $dest_file: " . error_get_last()["message"],
+                        PEAR_INSTALLER_FAILED);
                 }
 
                 $this->log(3, "+ cp $orig_file $dest_file");
@@ -605,13 +610,15 @@ class PEAR_Installer extends PEAR_Downloader
 
                     $wp = @fopen($dest_file, "wb");
                     if (!is_resource($wp)) {
-                        return $this->raiseError("failed to create $dest_file: $php_errormsg",
-                                                 PEAR_INSTALLER_FAILED);
+                        return $this->raiseError(
+                            "failed to create $dest_file: " . error_get_last()["message"],
+                            PEAR_INSTALLER_FAILED);
                     }
 
                     if (fwrite($wp, $contents) === false) {
-                        return $this->raiseError("failed writing to $dest_file: $php_errormsg",
-                                                 PEAR_INSTALLER_FAILED);
+                        return $this->raiseError(
+                            "failed writing to $dest_file: " . error_get_last()["message"],
+                            PEAR_INSTALLER_FAILED);
                     }
 
                     fclose($wp);
@@ -667,7 +674,8 @@ class PEAR_Installer extends PEAR_Downloader
                     $this->addFileOperation("chmod", array($mode, $dest_file));
                     if (!@chmod($dest_file, $mode)) {
                         if (!isset($options['soft'])) {
-                            $this->log(0, "failed to change mode of $dest_file: $php_errormsg");
+                            $this->log(0, "failed to change mode of $dest_file: " .
+                                          error_get_last()["message"]);
                         }
                     }
                 }
@@ -854,7 +862,7 @@ class PEAR_Installer extends PEAR_Downloader
 
                     if (!@copy($data[0], $data[0] . '.bak')) {
                         $this->log(1, 'Could not copy ' . $data[0] . ' to ' . $data[0] .
-                            '.bak ' . $php_errormsg);
+                            '.bak ' . error_get_last()["message"]);
                         return false;
                     }
                     $this->log(3, "+ backup $data[0] to $data[0].bak");
@@ -889,7 +897,7 @@ class PEAR_Installer extends PEAR_Downloader
                     $perms = @fileperms($data[0]);
                     if (!@copy($data[0], $data[1])) {
                         $this->log(1, 'Could not rename ' . $data[0] . ' to ' . $data[1] .
-                            ' ' . $php_errormsg);
+                            ' ' . error_get_last()["message"]);
                         return false;
                     }
 
@@ -901,7 +909,7 @@ class PEAR_Installer extends PEAR_Downloader
                 case 'chmod':
                     if (!@chmod($data[1], $data[0])) {
                         $this->log(1, 'Could not chmod ' . $data[1] . ' to ' .
-                            decoct($data[0]) . ' ' . $php_errormsg);
+                            decoct($data[0]) . ' ' . error_get_last()["message"]);
                         return false;
                     }
 
@@ -912,7 +920,7 @@ class PEAR_Installer extends PEAR_Downloader
                     if (file_exists($data[0])) {
                         if (!@unlink($data[0])) {
                             $this->log(1, 'Could not delete ' . $data[0] . ' ' .
-                                $php_errormsg);
+                                error_get_last()["message"]);
                             return false;
                         }
                         $this->log(3, "+ rm $data[0]");
@@ -934,7 +942,7 @@ class PEAR_Installer extends PEAR_Downloader
                             closedir($testme);
                             if (!@rmdir($data[0])) {
                                 $this->log(1, 'Could not rmdir ' . $data[0] . ' ' .
-                                    $php_errormsg);
+                                    error_get_last()["message"]);
                                 return false;
                             }
                             $this->log(3, "+ rmdir $data[0]");
@@ -1553,7 +1561,9 @@ class PEAR_Installer extends PEAR_Downloader
                 }
 
                 if (!@copy($ext['file'], $copyto)) {
-                    return $this->raiseError("failed to write $copyto ($php_errormsg)", PEAR_INSTALLER_FAILED);
+                    return $this->raiseError(
+                        "failed to write $copyto (" . error_get_last()["message"] . ")",
+                        PEAR_INSTALLER_FAILED);
                 }
 
                 $this->log(3, "+ cp $ext[file] $copyto");
@@ -1562,7 +1572,8 @@ class PEAR_Installer extends PEAR_Downloader
                     $mode = 0666 & ~(int)octdec($this->config->get('umask'));
                     $this->addFileOperation('chmod', array($mode, $copyto));
                     if (!@chmod($copyto, $mode)) {
-                        $this->log(0, "failed to change mode of $copyto ($php_errormsg)");
+                        $this->log(0, "failed to change mode of $copyto (" .
+                                      error_get_last()["message"] . ")");
                     }
                 }
             }

--- a/PEAR/PackageFile/v1.php
+++ b/PEAR/PackageFile/v1.php
@@ -1420,8 +1420,8 @@ class PEAR_PackageFile_v1
                 }
             }
             switch ($token) {
-                case T_WHITESPACE :
-                    continue;
+                case T_WHITESPACE:
+                    break;
                 case ';':
                     if ($interface) {
                         $current_function = '';

--- a/PEAR/PackageFile/v2.php
+++ b/PEAR/PackageFile/v2.php
@@ -423,12 +423,12 @@ class PEAR_PackageFile_v2
     function _unmatchedMaintainers($my, $yours)
     {
         if ($my) {
-            array_walk($my, create_function('&$i, $k', '$i = $i["handle"];'));
+            array_walk($my, function(&$i, $k) { $i = $i["handle"]; });
             $this->_stack->push(__FUNCTION__, 'error', array('handles' => $my),
                 'package.xml 2.0 has unmatched extra maintainers "%handles%"');
         }
         if ($yours) {
-            array_walk($yours, create_function('&$i, $k', '$i = $i["handle"];'));
+            array_walk($yours, function(&$i, $k) { $i = $i["handle"]; });
             $this->_stack->push(__FUNCTION__, 'error', array('handles' => $yours),
                 'package.xml 1.0 has unmatched extra maintainers "%handles%"');
         }

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -2064,7 +2064,7 @@ class PEAR_Registry extends PEAR
                 if (!class_exists('PEAR_Installer_Role')) {
                     require_once 'PEAR/Installer/Role.php';
                 }
-                $notempty = create_function('$a','return !empty($a);');
+                $notempty = function($a) { return !empty($a); };
             }
             $package = is_array($package) ? array(strtolower($package[0]), strtolower($package[1]))
                 : strtolower($package);

--- a/PEAR/RunTest.php
+++ b/PEAR/RunTest.php
@@ -64,7 +64,6 @@ class PEAR_RunTest
         'display_errors=1',
         'log_errors=0',
         'html_errors=0',
-        'track_errors=1',
         'report_memleaks=0',
         'report_zend_debug=0',
         'docref_root=',

--- a/scripts/pearcmd.php
+++ b/scripts/pearcmd.php
@@ -438,12 +438,11 @@ function cmdHelp($command)
  * @param mixed $errmsg Message
  * @param mixed $file   Filename
  * @param mixed $line   Line number
- * @param mixed $vars   Variables
  *
  * @access public
  * @return boolean
  */
-function error_handler($errno, $errmsg, $file, $line, $vars)
+function error_handler($errno, $errmsg, $file, $line)
 {
     if ($errno & E_STRICT
         || $errno & E_DEPRECATED

--- a/tests/PEAR/pear2.phpt
+++ b/tests/PEAR/pear2.phpt
@@ -66,7 +66,7 @@ class testErrorHandlingStatic {
         echoPEARStack('_PEAR_error_handler_stack', $GLOBALS['_PEAR_error_handler_stack']);
     }
     
-    function fakeHandleError($err)
+    static function fakeHandleError($err)
     {
     }
 }

--- a/tests/PEAR_Command_Install/upgrade/test_bug4060.phpt
+++ b/tests/PEAR_Command_Install/upgrade/test_bug4060.phpt
@@ -1339,7 +1339,7 @@ $phpunit->assertNoErrors('setup install');
 $fakelog->getDownload();
 $fakelog->getLog();
 $config->set('preferred_state', 'alpha');
-test_PEAR_Command_Install::_reset_downloader();
+$command->_reset_downloader();
 $res = $command->run('upgrade', array(), array('Auth_HTTP'));
 
 $dummy = null;

--- a/tests/PEAR_Error/pear_error.phpt
+++ b/tests/PEAR_Error/pear_error.phpt
@@ -22,7 +22,7 @@ if (!defined('E_DEPRECATED')) {
     define('E_DEPRECATED', -1);
 }
 
-function test_error_handler($errno, $errmsg, $file, $line, $vars) {
+function test_error_handler($errno, $errmsg, $file, $line) {
     if ($errno == E_STRICT) {
         return;
     }

--- a/tests/PEAR_ErrorStack/test_global_context_createfunction.phpt
+++ b/tests/PEAR_ErrorStack/test_global_context_createfunction.phpt
@@ -10,14 +10,14 @@ if (!getenv('PHP_PEAR_RUNTESTS')) {
 <?php
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
-$a = create_function('', '$GLOBALS["stack"]->push(3);');
+$a = function() { $GLOBALS["stack"]->push(3); };
 $testline = __LINE__ - 1;
 $a();
 
 $ret = $stack->pop();
 $phpunit->assertEquals(array('file' => __FILE__,
       'line' => $testline,
-      'function' => 'create_function() code',
+      'function' => '{closure}',
 ), $ret['context'], 'context');
 echo 'tests done';
 ?>

--- a/tests/PEAR_ErrorStack/test_global_context_createfunction_staticPush.phpt
+++ b/tests/PEAR_ErrorStack/test_global_context_createfunction_staticPush.phpt
@@ -10,14 +10,14 @@ if (!getenv('PHP_PEAR_RUNTESTS')) {
 <?php
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
-$a = create_function('', 'PEAR_ErrorStack::staticPush("test", 3);');
+$a = function() { PEAR_ErrorStack::staticPush("test", 3); };
 $testline = __LINE__ - 1;
 $a();
 
 $ret = $stack->pop();
 $phpunit->assertEquals(array('file' => __FILE__,
       'line' => $testline,
-      'function' => 'create_function() code',
+      'function' => '{closure}',
 ), $ret['context'], 'context');
 echo 'tests done';
 ?>

--- a/tests/PEAR_ErrorStack/test_infunction_context_createfunction.phpt
+++ b/tests/PEAR_ErrorStack/test_infunction_context_createfunction.phpt
@@ -10,7 +10,7 @@ if (!getenv('PHP_PEAR_RUNTESTS')) {
 <?php
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
-$a = create_function('', '$GLOBALS["stack"]->push(3);');
+$a = function() { $GLOBALS["stack"]->push(3); };
 $testline = __LINE__ - 1;
 function test7()
 {
@@ -22,7 +22,7 @@ test7();
 $ret = $stack->pop();
 $phpunit->assertEquals(array('file' => __FILE__,
       'line' => $testline,
-      'function' => 'create_function() code',
+      'function' => '{closure}',
 ), $ret['context'], 'context');
 echo 'tests done';
 ?>

--- a/tests/PEAR_ErrorStack/test_infunction_context_createfunction_staticPush.phpt
+++ b/tests/PEAR_ErrorStack/test_infunction_context_createfunction_staticPush.phpt
@@ -10,7 +10,7 @@ if (!getenv('PHP_PEAR_RUNTESTS')) {
 <?php
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
-$a = create_function('', 'PEAR_ErrorStack::staticPush("test", 3);');
+$a = function() { PEAR_ErrorStack::staticPush("test", 3); };
 $testline = __LINE__ - 1;
 function test7()
 {
@@ -22,7 +22,7 @@ test7();
 $ret = $stack->pop();
 $phpunit->assertEquals(array('file' => __FILE__,
       'line' => $testline,
-      'function' => 'create_function() code',
+      'function' => '{closure}',
 ), $ret['context'], 'context');
 echo 'tests done';
 ?>

--- a/tests/PEAR_ErrorStack/test_inmethod_context_createfunction.phpt
+++ b/tests/PEAR_ErrorStack/test_inmethod_context_createfunction.phpt
@@ -10,7 +10,7 @@ if (!getenv('PHP_PEAR_RUNTESTS')) {
 <?php
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
-$a = create_function('', '$GLOBALS["stack"]->push(3);');
+$a = function() { $GLOBALS["stack"]->push(3); };
 $testline = __LINE__ - 1;
 class test8
 {
@@ -26,7 +26,7 @@ $z->test7();
 $ret = $stack->pop();
 $phpunit->assertEquals(array('file' => __FILE__,
       'line' => $testline,
-      'function' => 'create_function() code',
+      'function' => '{closure}',
 ), $ret['context'], 'context');
 echo 'tests done';
 ?>

--- a/tests/PEAR_ErrorStack/test_inmethod_context_createfunction_staticPush.phpt
+++ b/tests/PEAR_ErrorStack/test_inmethod_context_createfunction_staticPush.phpt
@@ -10,7 +10,7 @@ if (!getenv('PHP_PEAR_RUNTESTS')) {
 <?php
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
-$a = create_function('', 'PEAR_ErrorStack::staticPush("test", 3);');
+$a = function() { PEAR_ErrorStack::staticPush("test", 3); };
 $testline = __LINE__ - 1;
 class test8
 {
@@ -26,7 +26,7 @@ $z->test7();
 $ret = $stack->pop();
 $phpunit->assertEquals(array('file' => __FILE__,
       'line' => $testline,
-      'function' => 'create_function() code',
+      'function' => '{closure}',
 ), $ret['context'], 'context');
 echo 'tests done';
 ?>

--- a/tests/PEAR_ErrorStack/test_instaticmethod_context.phpt
+++ b/tests/PEAR_ErrorStack/test_instaticmethod_context.phpt
@@ -12,7 +12,7 @@ require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
 class stclass
 {
-    function stfunc()
+    static function stfunc()
     {
         global $stack, $testline;
         $stack->push(3);

--- a/tests/PEAR_ErrorStack/test_instaticmethod_context_createfunction.phpt
+++ b/tests/PEAR_ErrorStack/test_instaticmethod_context_createfunction.phpt
@@ -10,7 +10,7 @@ if (!getenv('PHP_PEAR_RUNTESTS')) {
 <?php
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
-$a = create_function('', '$GLOBALS["stack"]->push(3);');
+$a = function() { $GLOBALS["stack"]->push(3); };
 $testline = __LINE__ - 1;
 class test8
 {
@@ -25,7 +25,7 @@ test8::test7();
 $ret = $stack->pop();
 $phpunit->assertEquals(array('file' => __FILE__,
       'line' => $testline,
-      'function' => 'create_function() code',
+      'function' => '{closure}',
 ), $ret['context'], 'context');
 echo 'tests done';
 ?>

--- a/tests/PEAR_ErrorStack/test_instaticmethod_context_createfunction.phpt
+++ b/tests/PEAR_ErrorStack/test_instaticmethod_context_createfunction.phpt
@@ -14,7 +14,7 @@ $a = function() { $GLOBALS["stack"]->push(3); };
 $testline = __LINE__ - 1;
 class test8
 {
-    function test7()
+    static function test7()
     {
         global $a;
         $a();

--- a/tests/PEAR_ErrorStack/test_instaticmethod_context_createfunction_staticPush.phpt
+++ b/tests/PEAR_ErrorStack/test_instaticmethod_context_createfunction_staticPush.phpt
@@ -10,7 +10,7 @@ if (!getenv('PHP_PEAR_RUNTESTS')) {
 <?php
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
-$a = create_function('', 'PEAR_ErrorStack::staticPush("test", 3);');
+$a = function() { PEAR_ErrorStack::staticPush("test", 3); };
 $testline = __LINE__ - 1;
 class test8
 {
@@ -25,7 +25,7 @@ test8::test7();
 $ret = $stack->pop();
 $phpunit->assertEquals(array('file' => __FILE__,
       'line' => $testline,
-      'function' => 'create_function() code',
+      'function' => '{closure}',
 ), $ret['context'], 'context');
 echo 'tests done';
 ?>

--- a/tests/PEAR_ErrorStack/test_instaticmethod_context_createfunction_staticPush.phpt
+++ b/tests/PEAR_ErrorStack/test_instaticmethod_context_createfunction_staticPush.phpt
@@ -14,7 +14,7 @@ $a = function() { PEAR_ErrorStack::staticPush("test", 3); };
 $testline = __LINE__ - 1;
 class test8
 {
-    function test7()
+    static function test7()
     {
         global $a;
         $a();

--- a/tests/PEAR_ErrorStack/test_instaticmethod_context_eval.phpt
+++ b/tests/PEAR_ErrorStack/test_instaticmethod_context_eval.phpt
@@ -12,7 +12,7 @@ require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
 class test3
 {
-    function test34()
+    static function test34()
     {
         global $testline, $stack;
         eval('$stack->push(3);');

--- a/tests/PEAR_ErrorStack/test_instaticmethod_context_eval_staticPush.phpt
+++ b/tests/PEAR_ErrorStack/test_instaticmethod_context_eval_staticPush.phpt
@@ -12,7 +12,7 @@ require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
 class test3
 {
-    function test34()
+    static function test34()
     {
         global $testline, $stack;
         eval('PEAR_ErrorStack::staticPush("test", 3);');

--- a/tests/PEAR_ErrorStack/test_instaticmethod_context_staticPush.phpt
+++ b/tests/PEAR_ErrorStack/test_instaticmethod_context_staticPush.phpt
@@ -12,7 +12,7 @@ require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'setup.php.inc';
 $stack = &PEAR_ErrorStack::singleton('test');
 class stclass
 {
-    function staticfunc()
+    static function staticfunc()
     {
         global $testline;
         PEAR_ErrorStack::staticPush('test', 3);

--- a/tests/download_test_classes.php.inc
+++ b/tests/download_test_classes.php.inc
@@ -525,8 +525,8 @@ class test_PEAR_Dependency2 extends PEAR_Dependency2
     var $_extensions;
     var $_installerVer;
 
-    function &singleton($config = null, $installoptions = null, $package = null,
-                              $state = PEAR_VALIDATE_INSTALLING)
+    static function &singleton($config = null, $installoptions = null, $package = null,
+                               $state = PEAR_VALIDATE_INSTALLING)
     {
         if (!isset($GLOBALS['_test_dep'])) {
             $GLOBALS['_test_dep'] = new test_PEAR_Dependency2($config,

--- a/tests/download_test_classes.php.inc
+++ b/tests/download_test_classes.php.inc
@@ -796,7 +796,7 @@ class fake_log extends PEAR_Frontend
 {
     var $_log = array();
     var $_download = array();
-    function fake_log()
+    function __construct()
     {
         $GLOBALS['_PEAR_FRONTEND_SINGLETON'] = &$GLOBALS['fakelog'];
     }

--- a/tests/phpt_test.php.inc
+++ b/tests/phpt_test.php.inc
@@ -336,7 +336,7 @@ class PEAR_PHPTest
     function assertPackageInfoEquals($control, $test, $message)
     {
         $this->assertNoErrors($message, debug_backtrace());
-        $a = create_function('$a,$b', 'return strcmp($a["name"],$b["name"]);');
+        $a = function($a, $b) { return strcmp($a["name"], $b["name"]); };
         if (isset($control[0])) {
             if (!isset($test[0]) || (count($control) != count($test))) {
                 echo "Invalid packageInfo\n";


### PR DESCRIPTION
This should be a comprehensive fix for all PHP 8 compatibility issues in pear-core. I believe that all the changes done here are both compatible with PHP 5.4 (minimum supported version by PEAR) and not BC breaking.

With this, all tests pass under PHP 8.

cc @ashnazg @torinaki