### PR TITLE
Fixes static calls for PHP 8

### DIFF
--- a/PEAR/Builder.php
+++ b/PEAR/Builder.php
@@ -276,7 +276,7 @@ class PEAR_Builder extends PEAR_Common
             } else {
                 $dir = $pkg->_config->get('temp_dir') . '/' . $pkg->getName();
                 // automatically delete at session end
-                $this->addTempFile($dir);
+                self::addTempFile($dir);
             }
         } else {
             $pf = new PEAR_PackageFile($this->config);
@@ -368,11 +368,11 @@ class PEAR_Builder extends PEAR_Common
             return $this->raiseError("could not create build dir: $build_dir");
         }
 
-        $this->addTempFile($build_dir);
+        self::addTempFile($build_dir);
         if (!System::mkDir(array('-p', $inst_dir))) {
             return $this->raiseError("could not create temporary install dir: $inst_dir");
         }
-        $this->addTempFile($inst_dir);
+        self::addTempFile($inst_dir);
 
         $make_command = getenv('MAKE') ? getenv('MAKE') : 'make';
 

--- a/PEAR/Common.php
+++ b/PEAR/Common.php
@@ -205,7 +205,7 @@ class PEAR_Common extends PEAR
      *
      * @access public
      */
-    function addTempFile($file)
+    static function addTempFile($file)
     {
         if (!class_exists('PEAR_Frontend')) {
             require_once 'PEAR/Frontend.php';
@@ -280,7 +280,7 @@ class PEAR_Common extends PEAR
             return false;
         }
 
-        $this->addTempFile($tmpdir);
+        self::addTempFile($tmpdir);
         return $tmpdir;
     }
 

--- a/PEAR/Frontend.php
+++ b/PEAR/Frontend.php
@@ -160,7 +160,7 @@ class PEAR_Frontend extends PEAR
      * needs to be able to sustain a list over many sessions in order to support
      * user interaction with install scripts
      */
-    function addTempFile($file)
+    static function addTempFile($file)
     {
         $GLOBALS['_PEAR_Common_tempfiles'][] = $file;
     }

--- a/PEAR/PackageFile.php
+++ b/PEAR/PackageFile.php
@@ -283,7 +283,7 @@ class PEAR_PackageFile
      * @param string  $file  name of file or directory
      * @return  void
      */
-    function addTempFile($file)
+    static function addTempFile($file)
     {
         $GLOBALS['_PEAR_Common_tempfiles'][] = $file;
     }


### PR DESCRIPTION
Fixes issue during `pecl install`
```
Fatal error: Uncaught Error: Non-static method PEAR_Frontend::addTempFile() cannot be called statically in /usr/local/lib/php/PEAR/Common.php:213
Stack trace:
#0 /usr/local/lib/php/PEAR/Builder.php(279): PEAR_Common->addTempFile('/tmp/pear/temp/...')
#1 /usr/local/lib/php/PEAR/Installer.php(1519): PEAR_Builder->build('/tmp/pear/temp/...', Array)
#2 /usr/local/lib/php/PEAR/Installer.php(1415): PEAR_Installer->_compileSourceFiles('pecl.php.net', Object(PEAR_PackageFile_v2))
#3 /usr/local/lib/php/PEAR/Command/Install.php(713): PEAR_Installer->install('/tmp/pear/downl...', Array)
#4 /usr/local/lib/php/PEAR/Command/Common.php(270): PEAR_Command_Install->doInstall('install', Array, Array)
#5 /usr/local/lib/php/pearcmd.php(316): PEAR_Command_Common->run('install', Array, Array)
#6 /usr/local/lib/php/peclcmd.php(31): require_once('/usr/local/lib/...')
#7 {main}
  thrown in /usr/local/lib/php/PEAR/Common.php on line 213
```