### PR TITLE
Adjust silencing check for PHP 8

### DIFF
--- a/scripts/pearcmd.php
+++ b/scripts/pearcmd.php
@@ -444,19 +444,17 @@ function cmdHelp($command)
  */
 function error_handler($errno, $errmsg, $file, $line)
 {
-    if ($errno & E_STRICT
-        || $errno & E_DEPRECATED
-        || !error_reporting()
+    if ($errno & E_STRICT) {
+        return; // E_STRICT
+    }
+    if ($errno & E_DEPRECATED) {
+        return; // E_DEPRECATED
+    }
+    if (!(error_reporting() & $errno) &&
+        isset($GLOBALS['config']) &&
+        $GLOBALS['config']->get('verbose') < 4
     ) {
-        if ($errno & E_STRICT) {
-            return; // E_STRICT
-        }
-        if ($errno & E_DEPRECATED) {
-            return; // E_DEPRECATED
-        }
-        if (!error_reporting() && isset($GLOBALS['config']) && $GLOBALS['config']->get('verbose') < 4) {
-            return false; // @silenced error, show all if debug is high enough
-        }
+        return false; // @silenced error, show all if debug is high enough
     }
     $errortype = array (
         E_DEPRECATED  => 'Deprecated Warning',


### PR DESCRIPTION
To account for https://github.com/php/php-src/commit/a302d1161036988fe220ecd8ecd73e6af1a116fc. Otherwise a whole flood of silenced warnings gets displayed :)