### PR TITLE
Fix scripts/* include paths

### DIFF
--- a/scripts/pearcmd.php
+++ b/scripts/pearcmd.php
@@ -31,6 +31,7 @@ if ('@include_path@ ' != '@'.'include_path'.'@ ') {
     $raw = false;
 } else {
     // this is a raw, uninstalled pear, either a cvs checkout, or php distro
+    ini_set('include_path', dirname(__DIR__) . PATH_SEPARATOR . get_include_path());
     $raw = true;
 }
 @ini_set('allow_url_fopen', true);

--- a/scripts/peclcmd.php
+++ b/scripts/peclcmd.php
@@ -25,6 +25,7 @@ if ('@include_path@ ' != '@'.'include_path'.'@ ') {
     $raw = false;
 } else {
     // this is a raw, uninstalled pear, either a cvs checkout, or php distro
+    ini_set('include_path', __DIR__ . PATH_SEPARATOR . get_include_path());
     $raw = true;
 }
 define('PEAR_RUNTYPE', 'pecl');


### PR DESCRIPTION
I was confused by why my PECL-specific changes didn't seem to be doing anything until I realised that `peclcmd.php` doesn't specify an absolute path for `pearcmd.php`, instead falling back to `include_path`. If PEAR is installed on the system the include_path will by default include `/usr/share/php`, resulting in us incorrectly(?) including the installed version rather than the "raw" one in the checkout.

I also noticed that only `.` appears in `include_path`, not specifically the root directory of the checkout. This means executing e.g. `../pear/scripts/pecl.sh build` from within a PECL extension directory will include the system PEAR files rather than the raw checkout.

From the commit log:
* The scripts/ directory itself should appear in include_path if we're
  relying on it to source pearcmd from within peclcmd, else we'll
  include the system pearcmd.
* The root directory (parent of scripts/) should always be in
  include_path on a raw checkout.