### PR TITLE
Non-interactive <configureoption /> answers

### DIFF
--- a/PEAR/Builder.php
+++ b/PEAR/Builder.php
@@ -392,21 +392,19 @@ class PEAR_Builder extends PEAR_Common
 
         $configure_options = $pkg->getConfigureOptions();
         if ($configure_options) {
-            foreach ($configure_options as $o) {
-                $default = array_key_exists('default', $o) ? $o['default'] : null;
-                if (array_key_exists($o['name'], $this->_parsed_configure_options)) {
-                    $r = $this->_parsed_configure_options[$o['name']];
+            foreach ($configure_options as $option) {
+                $default = array_key_exists('default', $option) ? $option['default'] : null;
+                if (array_key_exists($option['name'], $this->_parsed_configure_options)) {
+                    $response = $this->_parsed_configure_options[$option['name']];
                 } else {
-                    list($r) = $this->ui->userDialog('build',
-                                                     array($o['prompt']),
-                                                     array('text'),
-                                                     array($default));
+                    list($response) = $this->ui->userDialog(
+                            'build', [$option['prompt']], ['text'], [$default]);
                 }
-                if (substr($o['name'], 0, 5) == 'with-' &&
-                    ($r == 'yes' || $r == 'autodetect')) {
-                    $configure_command .= " --$o[name]";
+                if (substr($option['name'], 0, 5) === 'with-' &&
+                    ($response === 'yes' || $response === 'autodetect')) {
+                    $configure_command .= " --{$option[name]}";
                 } else {
-                    $configure_command .= " --$o[name]=".trim($r);
+                    $configure_command .= " --{$option[name]}=".trim($response);
                 }
             }
         }

--- a/PEAR/Builder.php
+++ b/PEAR/Builder.php
@@ -57,16 +57,71 @@ class PEAR_Builder extends PEAR_Common
     var $_firstline = null;
 
     /**
+     * Parsed --configureoptions.
+     *
+     * @var mixed[]
+     */
+    var $_parsed_configure_options;
+
+    /**
      * PEAR_Builder constructor.
      *
+     * @param mixed[] $configureoptions
      * @param object $ui user interface object (instance of PEAR_Frontend_*)
      *
      * @access public
      */
-    function __construct(&$ui)
+    function __construct($configureoptions, &$ui)
     {
         parent::__construct();
         $this->setFrontendObject($ui);
+        $this->_parseConfigureOptions($configureoptions);
+    }
+
+    /**
+     * Parse --configureoptions string.
+     *
+     * @param string Options, in the form "X=1 Y=2 Z='there\'s always one'"
+     */
+    function _parseConfigureOptions($options)
+    {
+        $data = '<XML><PROPERTIES ' . $options . ' /></XML>';
+        $parser = xml_parser_create('ISO-8859-1');
+        xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
+        xml_set_element_handler(
+            $parser, array($this, '_parseConfigureOptionsStartElement'),
+            array($this, '_parseConfigureOptionsEndElement'));
+        xml_parse($parser, $data, true);
+        xml_parser_free($parser);
+    }
+
+    /**
+     * Handle element start.
+     *
+     * @see PEAR_Builder::_parseConfigureOptions()
+     *
+     * @param resource $parser
+     * @param string $tagName
+     * @param mixed[] $attribs
+     */
+    function _parseConfigureOptionsStartElement($parser, $tagName, $attribs)
+    {
+        if ($tagName !== 'PROPERTIES') {
+            return;
+        }
+        $this->_parsed_configure_options = $attribs;
+    }
+
+    /**
+     * Handle element end.
+     *
+     * @see PEAR_Builder::_parseConfigureOptions()
+     *
+     * @param resource
+     * @param string $element
+     */
+    function _parseConfigureOptionsEndElement($parser, $element)
+    {
     }
 
     /**
@@ -339,10 +394,14 @@ class PEAR_Builder extends PEAR_Common
         if ($configure_options) {
             foreach ($configure_options as $o) {
                 $default = array_key_exists('default', $o) ? $o['default'] : null;
-                list($r) = $this->ui->userDialog('build',
-                                                 array($o['prompt']),
-                                                 array('text'),
-                                                 array($default));
+                if (array_key_exists($o['name'], $this->_parsed_configure_options)) {
+                    $r = $this->_parsed_configure_options[$o['name']];
+                } else {
+                    list($r) = $this->ui->userDialog('build',
+                                                     array($o['prompt']),
+                                                     array('text'),
+                                                     array($default));
+                }
                 if (substr($o['name'], 0, 5) == 'with-' &&
                     ($r == 'yes' || $r == 'autodetect')) {
                     $configure_command .= " --$o[name]";

--- a/PEAR/Command/Build.php
+++ b/PEAR/Command/Build.php
@@ -41,7 +41,13 @@ class PEAR_Command_Build extends PEAR_Command_Common
             'summary' => 'Build an Extension From C Source',
             'function' => 'doBuild',
             'shortcut' => 'b',
-            'options' => array(),
+            'options' => array(
+                'configureoptions' => array(
+                    'shortopt' => 'D',
+                    'arg' => 'OPTION1=VALUE[ OPTION2=VALUE]',
+                    'doc' => 'space-delimited list of configure options',
+                    ),
+                ),
             'doc' => '[package.xml]
 Builds one or more extensions contained in a package.'
             ),
@@ -64,7 +70,8 @@ Builds one or more extensions contained in a package.'
             $params[0] = 'package.xml';
         }
 
-        $builder = new PEAR_Builder($this->ui);
+        $configureoptions = empty($options['configureoptions']) ? '' : $options['configureoptions'];
+        $builder = new PEAR_Builder($configureoptions, $this->ui);
         $this->debug = $this->config->get('verbose');
         $err = $builder->build($params[0], array(&$this, 'buildCallback'));
         if (PEAR::isError($err)) {

--- a/PEAR/Command/Build.xml
+++ b/PEAR/Command/Build.xml
@@ -3,7 +3,12 @@
   <summary>Build an Extension From C Source</summary>
   <function>doBuild</function>
   <shortcut>b</shortcut>
-  <options />
+  <options>
+   <configureoptions>
+    <shortopt>D</shortopt>
+    <arg>OPTION1=VALUE[ OPTION2=VALUE]</arg>
+   </configureoptions>
+  </options>
   <doc>[package.xml]
 Builds one or more extensions contained in a package.</doc>
  </build>

--- a/PEAR/Command/Install.php
+++ b/PEAR/Command/Install.php
@@ -67,6 +67,11 @@ class PEAR_Command_Install extends PEAR_Command_Common
                     'shortopt' => 'B',
                     'doc' => 'don\'t build C extensions',
                     ),
+                'configureoptions' => array(
+                    'shortopt' => 'D',
+                    'arg' => 'OPTION1=VALUE[ OPTION2=VALUE]',
+                    'doc' => 'space-delimited list of configure options',
+                    ),
                 'nocompress' => array(
                     'shortopt' => 'Z',
                     'doc' => 'request uncompressed files when downloading',

--- a/PEAR/Command/Install.xml
+++ b/PEAR/Command/Install.xml
@@ -28,6 +28,10 @@
     <shortopt>B</shortopt>
     <doc>don&#039;t build C extensions</doc>
    </nobuild>
+   <configureoptions>
+    <shortopt>D</shortopt>
+    <arg>OPTION1=VALUE[ OPTION2=VALUE]</arg>
+   </configureoptions>
    <nocompress>
     <shortopt>Z</shortopt>
     <doc>request uncompressed files when downloading</doc>

--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -62,11 +62,12 @@ class PEAR_Downloader extends PEAR_Common
      * Options from command-line passed to Install.
      *
      * Recognized options:<br />
-     *  - onlyreqdeps   : install all required dependencies as well
-     *  - alldeps       : install all dependencies, including optional
-     *  - installroot   : base relative path to install files in
-     *  - force         : force a download even if warnings would prevent it
-     *  - nocompress    : download uncompressed tarballs
+     *  - onlyreqdeps      : install all required dependencies as well
+     *  - alldeps          : install all dependencies, including optional
+     *  - installroot      : base relative path to install files in
+     *  - force            : force a download even if warnings would prevent it
+     *  - nocompress       : download uncompressed tarballs
+     *  - configureoptions : additional configure options
      * @see PEAR_Command_Install
      * @access private
      * @var array

--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -1411,8 +1411,9 @@ class PEAR_Installer extends PEAR_Downloader
 
         // {{{ compile and install source files
         if ($this->source_files > 0 && empty($options['nobuild'])) {
+            $configureoptions = empty($options['configureoptions']) ? '' : $options['configureoptions'];
             if (PEAR::isError($err =
-                  $this->_compileSourceFiles($savechannel, $pkg))) {
+                  $this->_compileSourceFiles($savechannel, $pkg, $configureoptions))) {
                 return $err;
             }
         }
@@ -1509,12 +1510,13 @@ class PEAR_Installer extends PEAR_Downloader
     /**
      * @param string
      * @param PEAR_PackageFile_v1|PEAR_PackageFile_v2
+     * @param mixed[] $configureoptions
      */
-    function _compileSourceFiles($savechannel, &$filelist)
+    function _compileSourceFiles($savechannel, &$filelist, $configureoptions)
     {
         require_once 'PEAR/Builder.php';
         $this->log(1, "$this->source_files source files, building");
-        $bob = new PEAR_Builder($this->ui);
+        $bob = new PEAR_Builder($configureoptions, $this->ui);
         $bob->debug = $this->debug;
         $built = $bob->build($filelist, array(&$this, '_buildCallback'));
         if (PEAR::isError($built)) {

--- a/tests/PEAR_Command/test_registerCommands_standard.phpt
+++ b/tests/PEAR_Command/test_registerCommands_standard.phpt
@@ -115,8 +115,10 @@ $phpunit->assertEquals(array (
   'up' => 'upgrade',
 ), PEAR_Command::getShortcuts(), 'getshortcuts');
 PEAR_Command::getGetoptArgs('build', $s, $l);
-$phpunit->assertEquals('', $s, 'short build');
-$phpunit->assertEquals(array(), $l, 'long build');
+$phpunit->assertEquals('D:', $s, 'short build');
+$phpunit->assertEquals(array(
+  0 => 'configureoptions=',
+), $l, 'long build');
 PEAR_Command::getGetoptArgs('bundle', $s, $l);
 $phpunit->assertEquals('d:f', $s, 'short bundle');
 $phpunit->assertEquals(array('destination=', 'force'), $l, 'long bundle');
@@ -191,7 +193,7 @@ PEAR_Command::getGetoptArgs('info', $s, $l);
 $phpunit->assertEquals('', $s, 'short info');
 $phpunit->assertEquals(array(), $l, 'long info');
 PEAR_Command::getGetoptArgs('install', $s, $l);
-$phpunit->assertEquals('flnrsBZR:P:aoOp', $s, 'short install');
+$phpunit->assertEquals('flnrsBD:ZR:P:aoOp', $s, 'short install');
 $phpunit->assertEquals(array (
   0 => 'force',
   1 => 'loose',
@@ -199,14 +201,15 @@ $phpunit->assertEquals(array (
   3 => 'register-only',
   4 => 'soft',
   5 => 'nobuild',
-  6 => 'nocompress',
-  7 => 'installroot=',
-  8 => 'packagingroot=',
-  9 => 'ignore-errors',
-  10 => 'alldeps',
-  11 => 'onlyreqdeps',
-  12 => 'offline',
-  13 => 'pretend',
+  6 => 'configureoptions=',
+  7 => 'nocompress',
+  8 => 'installroot=',
+  9 => 'packagingroot=',
+  10 => 'ignore-errors',
+  11 => 'alldeps',
+  12 => 'onlyreqdeps',
+  13 => 'offline',
+  14 => 'pretend',
 ), $l, 'long install');
 PEAR_Command::getGetoptArgs('list', $s, $l);
 $phpunit->assertEquals('c:ai', $s, 'short list');


### PR DESCRIPTION
I'm currently working on automating installation of a PHP extension via PECL from within a configuration management tool, but extensions with mandatory `<configureoption>`s currently require answers interactively. This forces me to either spam `stdin` with a fixed set of inputs (flaky) or use `expect` (also flake).

These changes:
* Introduce new `--configureoptions` (`-D`) switch for `build` and `install` commands
* Add rudimentary configuration option parsing to `PEAR_Builder`
* Only prompt for user input if no value exists in the parsed options
* Patch up tests to accommodate new switch

I realise further changes might be necessary to get this mergeable:
1. Argument parsing is a bit gross (using an XML parser to resolve key-value pairs from a string of options... how else could I do this?).
2. I assume the `update` command should also honour these options?
3. Is there any way I can retain the user's answers to the questions so they may be re-applied during an `update-all`?
4. Should we also add an option that strictly enforces non-interactive installation, exiting unsuccessfully if a mandatory option isn't answered by the options string?