### PR TITLE
Added missing preg quote

### DIFF
--- a/PEAR/Builder.php
+++ b/PEAR/Builder.php
@@ -307,8 +307,9 @@ class PEAR_Builder extends PEAR_Common
 
         $dir = getcwd();
         $this->log(2, "building in $dir");
-        if (!preg_match('@(^|:)' . $this->config->get('bin_dir') . '(:|$)@', getenv('PATH'))) {
-            putenv('PATH=' . $this->config->get('bin_dir') . ':' . getenv('PATH'));
+        $binDir = $this->config->get('bin_dir');
+        if (!preg_match('@(^|:)' . preg_quote($binDir, '@') . '(:|$)@', getenv('PATH'))) {
+            putenv('PATH=' . $binDir . ':' . getenv('PATH'));
         }
         $err = $this->_runCommand($this->config->get('php_prefix')
                                 . "phpize" .


### PR DESCRIPTION
When having an @ in the php bin_dir (default for PHP installations on OSX with Homebrew), the preg_match fails. Dynamic values should be filtered by preg_quote to prevent issues like this.

Related to "Merge pull request pear#88 from remicollet/issue-75852"