### PR TITLE
handle "lib64" case for glibc detection

### DIFF
--- a/OS/Guess.php
+++ b/OS/Guess.php
@@ -195,9 +195,22 @@ class OS_Guess
         }
         $major = $minor = 0;
         include_once "System.php";
+
+        if (@is_link('/lib64/libc.so.6')) {
+            // Let's try reading the libc.so.6 symlink
+            if (preg_match('/^libc-(.*)\.so$/', basename(readlink('/lib64/libc.so.6')), $matches)) {
+                list($major, $minor) = explode('.', $matches[1]);
+            }
+        } else if (@is_link('/lib/libc.so.6')) {
+            // Let's try reading the libc.so.6 symlink
+            if (preg_match('/^libc-(.*)\.so$/', basename(readlink('/lib/libc.so.6')), $matches)) {
+                list($major, $minor) = explode('.', $matches[1]);
+            }
+        }
         // Use glibc's <features.h> header file to
         // get major and minor version number:
-        if (@file_exists('/usr/include/features.h') &&
+        if (!($major && $minor) &&
+              @file_exists('/usr/include/features.h') &&
               @is_readable('/usr/include/features.h')) {
             if (!@file_exists('/usr/bin/cpp') || !@is_executable('/usr/bin/cpp')) {
                 $features_file = fopen('/usr/include/features.h', 'rb');
@@ -251,13 +264,6 @@ class OS_Guess
             pclose($cpp);
             unlink($tmpfile);
         } // features.h
-
-        if (!($major && $minor) && @is_link('/lib/libc.so.6')) {
-            // Let's try reading the libc.so.6 symlink
-            if (preg_match('/^libc-(.*)\.so$/', basename(readlink('/lib/libc.so.6')), $matches)) {
-                list($major, $minor) = explode('.', $matches[1]);
-            }
-        }
 
         if (!($major && $minor)) {
             return $glibc = '';


### PR DESCRIPTION
Also move the "simple" way first
to avoid file parsing or shell call

Notice: it seems that this information if not really used anywhere
and I'm not aware of any pear/pecl package with constraint on glibc version