### PR TITLE
Updated logic in useLocalCache to reuse getCacheId

### DIFF
--- a/PEAR/REST.php
+++ b/PEAR/REST.php
@@ -173,13 +173,7 @@ class PEAR_REST
     function useLocalCache($url, $cacheid = null)
     {
         if (!is_array($cacheid)) {
-            $cacheidfile = $this->config->get('cache_dir') . DIRECTORY_SEPARATOR .
-                md5($url) . 'rest.cacheid';
-            if (!file_exists($cacheidfile)) {
-                return false;
-            }
-
-            $cacheid = unserialize(implode('', file($cacheidfile)));
+            $cacheid = $this->getCacheId($url);
         }
 
         $cachettl = $this->config->get('cache_ttl');
@@ -191,6 +185,11 @@ class PEAR_REST
         return false;
     }
 
+    /**
+     * @param string $url
+     *
+     * @return bool|mixed
+     */
     function getCacheId($url)
     {
         $cacheidfile = $this->config->get('cache_dir') . DIRECTORY_SEPARATOR .


### PR DESCRIPTION
While fixing notice (which was actually fixed in #93 by @remicollet) noticed that logic in `useLocalCache` is duplicate with `getCacheId`

This PR aims to remove duplicate code.