### PR TITLE
Fix manpage warning

### DIFF
--- a/man1/pear.1
+++ b/man1/pear.1
@@ -227,16 +227,19 @@ The user configuration.
 .SH SEE ALSO
 .TP
 To list all options, use
-.PS
+.EX
 pear help options
+.EE
 .TP
 To list all command shortcuts, use
-.PS
+.EX
 pear help shortcuts
+.EE
 .TP
 to get the help for the specified command, use
-.PS
+.EX
 pear help \fIcommand\fP
+.EE
 .TP
 Documentation for PEAR can be found at
 .PD 0


### PR DESCRIPTION
```shell
LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
  man --warnings -E UTF-8 -l -Tutf8 -Z man1/pear.1 > /dev/null
```
Outputs:
```
troff: <standard input>:230: warning: macro 'PS' not defined
```

We use "Example begin" (`.EX`)/"Example end" (`.EE`) instead, see [groff_man(7)](https://manpages.debian.org/unstable/groff/groff_man.7).