### PR TITLE
Fix PHP 7.4 deprecation: array/string curly braces access

### DIFF
--- a/OS/Guess.php
+++ b/OS/Guess.php
@@ -253,7 +253,7 @@ class OS_Guess
             fclose($fp);
             $cpp = popen("/usr/bin/cpp $tmpfile", "r");
             while ($line = fgets($cpp, 1024)) {
-                if ($line{0} == '#' || trim($line) == '') {
+                if ($line[0] == '#' || trim($line) == '') {
                     continue;
                 }
 

--- a/PEAR/Builder.php
+++ b/PEAR/Builder.php
@@ -191,7 +191,7 @@ class PEAR_Builder extends PEAR_Common
 
         $ret = true;
         while (($ent = readdir($d)) !== false) {
-            if ($ent{0} == '.')
+            if ($ent[0] == '.')
                 continue;
 
             $full = $dirname . DIRECTORY_SEPARATOR . $ent;

--- a/PEAR/Command.php
+++ b/PEAR/Command.php
@@ -233,7 +233,7 @@ class PEAR_Command
         }
 
         while ($file = readdir($dp)) {
-            if ($file{0} == '.' || substr($file, -4) != '.xml') {
+            if ($file[0] == '.' || substr($file, -4) != '.xml') {
                 continue;
             }
 

--- a/PEAR/Command/Channels.php
+++ b/PEAR/Command/Channels.php
@@ -673,7 +673,7 @@ configuration.',
             return $this->raiseError('No channel alias specified');
         }
 
-        if (count($params) !== 2 || (!empty($params[1]) && $params[1]{0} == '-')) {
+        if (count($params) !== 2 || (!empty($params[1]) && $params[1][0] == '-')) {
             return $this->raiseError(
                 'Invalid format, correct is: channel-alias channel alias');
         }

--- a/PEAR/Command/Common.php
+++ b/PEAR/Command/Common.php
@@ -146,7 +146,7 @@ class PEAR_Command_Common extends PEAR
         foreach ($this->commands[$command]['options'] as $option => $info) {
             $larg = $sarg = '';
             if (isset($info['arg'])) {
-                if ($info['arg']{0} == '(') {
+                if ($info['arg'][0] == '(') {
                     $larg = '==';
                     $sarg = '::';
                     $arg = substr($info['arg'], 1, -1);

--- a/PEAR/Command/Config.php
+++ b/PEAR/Command/Config.php
@@ -315,7 +315,7 @@ and uninstall).
         $root = preg_replace(array('!\\\\+!', '!/+!', "!$ds2+!"),
                              array('/', '/', '/'),
                             $root);
-        if ($root{0} != '/') {
+        if ($root[0] != '/') {
             if (!isset($options['windows'])) {
                 return PEAR::raiseError('Root directory must be an absolute path beginning ' .
                     'with "/", was: "' . $root . '"');
@@ -338,7 +338,7 @@ and uninstall).
 
         $params[1] = realpath($params[1]);
         $config = new PEAR_Config($params[1], '#no#system#config#', false, false);
-        if ($root{strlen($root) - 1} == '/') {
+        if ($root[strlen($root) - 1] == '/') {
             $root = substr($root, 0, strlen($root) - 1);
         }
 

--- a/PEAR/Common.php
+++ b/PEAR/Common.php
@@ -686,7 +686,7 @@ class PEAR_Common extends PEAR
             foreach ($methods as $method) {
                 $function = "$class::$method";
                 $key = "function;$function";
-                if ($method{0} == '_' || !strcasecmp($method, $class) ||
+                if ($method[0] == '_' || !strcasecmp($method, $class) ||
                     isset($this->pkginfo['provides'][$key])) {
                     continue;
                 }
@@ -698,7 +698,7 @@ class PEAR_Common extends PEAR
 
         foreach ($srcinfo['declared_functions'] as $function) {
             $key = "function;$function";
-            if ($function{0} == '_' || isset($this->pkginfo['provides'][$key])) {
+            if ($function[0] == '_' || isset($this->pkginfo['provides'][$key])) {
                 continue;
             }
 

--- a/PEAR/Config.php
+++ b/PEAR/Config.php
@@ -2092,7 +2092,7 @@ class PEAR_Config extends PEAR
             if (OS_WINDOWS && preg_match('/^[a-z]:/i', $path)) {
                 if (preg_match('/^[a-z]:/i', $prepend)) {
                     $prepend = substr($prepend, 2);
-                } elseif ($prepend{0} != '\\') {
+                } elseif ($prepend[0] != '\\') {
                     $prepend = "\\$prepend";
                 }
                 $path = substr($path, 0, 2) . $prepend . substr($path, 2);

--- a/PEAR/DependencyDB.php
+++ b/PEAR/DependencyDB.php
@@ -174,7 +174,7 @@ class PEAR_DependencyDB
             $this->rebuildDB();
         }
 
-        if ($depdb['_version']{0} > $this->_version[0]) {
+        if ($depdb['_version'][0] > $this->_version[0]) {
             return PEAR::raiseError('Dependency database is version ' .
                 $depdb['_version'] . ', and we are version ' .
                 $this->_version . ', cannot continue');

--- a/PEAR/DependencyDB.php
+++ b/PEAR/DependencyDB.php
@@ -174,7 +174,7 @@ class PEAR_DependencyDB
             $this->rebuildDB();
         }
 
-        if ($depdb['_version']{0} > $this->_version{0}) {
+        if ($depdb['_version']{0} > $this->_version[0]) {
             return PEAR::raiseError('Dependency database is version ' .
                 $depdb['_version'] . ', and we are version ' .
                 $this->_version . ', cannot continue');

--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -1156,7 +1156,7 @@ class PEAR_Downloader extends PEAR_Common
             if (OS_WINDOWS && preg_match('/^[a-z]:/i', $path)) {
                 if (preg_match('/^[a-z]:/i', $prepend)) {
                     $prepend = substr($prepend, 2);
-                } elseif ($prepend{0} != '\\') {
+                } elseif ($prepend[0] != '\\') {
                     $prepend = "\\$prepend";
                 }
                 $path = substr($path, 0, 2) . $prepend . substr($path, 2);

--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -225,7 +225,7 @@ class PEAR_Installer extends PEAR_Downloader
                 $os = new OS_Guess();
             }
 
-            if (strlen($atts['platform']) && $atts['platform']{0} == '!') {
+            if (strlen($atts['platform']) && $atts['platform'][0] == '!') {
                 $negate   = true;
                 $platform = substr($atts['platform'], 1);
             } else {

--- a/PEAR/Installer/Role.php
+++ b/PEAR/Installer/Role.php
@@ -237,7 +237,7 @@ class PEAR_Installer_Role
         }
 
         while ($entry = readdir($dp)) {
-            if ($entry{0} == '.' || substr($entry, -4) != '.xml') {
+            if ($entry[0] == '.' || substr($entry, -4) != '.xml') {
                 continue;
             }
 

--- a/PEAR/PackageFile.php
+++ b/PEAR/PackageFile.php
@@ -94,13 +94,13 @@ class PEAR_PackageFile
      */
     function &parserFactory($version)
     {
-        if (!in_array($version{0}, array('1', '2'))) {
+        if (!in_array($version[0], array('1', '2'))) {
             $a = false;
             return $a;
         }
 
-        include_once 'PEAR/PackageFile/Parser/v' . $version{0} . '.php';
-        $version = $version{0};
+        include_once 'PEAR/PackageFile/Parser/v' . $version[0] . '.php';
+        $version = $version[0];
         $class = "PEAR_PackageFile_Parser_v$version";
         $a = new $class;
         return $a;
@@ -122,13 +122,13 @@ class PEAR_PackageFile
      */
     function &factory($version)
     {
-        if (!in_array($version{0}, array('1', '2'))) {
+        if (!in_array($version[0], array('1', '2'))) {
             $a = false;
             return $a;
         }
 
-        include_once 'PEAR/PackageFile/v' . $version{0} . '.php';
-        $version = $version{0};
+        include_once 'PEAR/PackageFile/v' . $version[0] . '.php';
+        $version = $version[0];
         $class = $this->getClassPrefix() . $version;
         $a = new $class;
         return $a;

--- a/PEAR/PackageFile/Generator/v1.php
+++ b/PEAR/PackageFile/Generator/v1.php
@@ -904,7 +904,7 @@ class PEAR_PackageFile_Generator_v1
                 if (isset($package['install-as'][$file])) {
                     continue;
                 }
-                if ($platform{0} != '!') {
+                if ($platform[0] != '!') {
                     //o <ignore> tags for <file name=... platform=...>
                     $genericIgnore[] = $file;
                 }
@@ -913,7 +913,7 @@ class PEAR_PackageFile_Generator_v1
                 $oses = $notplatform = $platform = array();
                 foreach ($package['platform'] as $file => $os) {
                     // get a list of oses
-                    if ($os{0} == '!') {
+                    if ($os[0] == '!') {
                         if (isset($oses[substr($os, 1)])) {
                             continue;
                         }
@@ -1010,7 +1010,7 @@ class PEAR_PackageFile_Generator_v1
                             continue;
                         }
                         //o <ignore> tags for <file name=... platform=other platform>
-                        if ($platform{0} != '!' && $platform != $os) {
+                        if ($platform[0] != '!' && $platform != $os) {
                             $release[$releaseNum]['filelist']['ignore'][] =
                                 array(
                                     'attribs' => array(

--- a/PEAR/PackageFile/Generator/v1.php
+++ b/PEAR/PackageFile/Generator/v1.php
@@ -889,13 +889,13 @@ class PEAR_PackageFile_Generator_v1
                 }
                 //o <install as=..> tags for <file name=... platform=!... install-as=..>
                 if (isset($package['platform'][$file]) &&
-                      $package['platform'][$file]{0} == '!') {
+                      $package['platform'][$file][0] == '!') {
                     $generic[] = $file;
                     continue;
                 }
                 //o <ignore> tags for <file name=... platform=... install-as=..>
                 if (isset($package['platform'][$file]) &&
-                      $package['platform'][$file]{0} != '!') {
+                      $package['platform'][$file][0] != '!') {
                     $genericIgnore[] = $file;
                     continue;
                 }
@@ -959,7 +959,7 @@ class PEAR_PackageFile_Generator_v1
                         //  <file name=... platform=!other platform install-as=..>
                         if (isset($package['platform'][$file]) &&
                               $package['platform'][$file] != "!$os" &&
-                              $package['platform'][$file]{0} == '!') {
+                              $package['platform'][$file][0] == '!') {
                             $release[$releaseNum]['filelist']['install'][] =
                                 array(
                                     'attribs' => array(
@@ -984,7 +984,7 @@ class PEAR_PackageFile_Generator_v1
                         //o <ignore> tags for
                         //  <file name=... platform=other platform install-as=..>
                         if (isset($package['platform'][$file]) &&
-                              $package['platform'][$file]{0} != '!' &&
+                              $package['platform'][$file][0] != '!' &&
                               $package['platform'][$file] != $os) {
                             $release[$releaseNum]['filelist']['ignore'][] =
                                 array(

--- a/PEAR/PackageFile/Generator/v2.php
+++ b/PEAR/PackageFile/Generator/v2.php
@@ -781,7 +781,7 @@ http://pear.php.net/dtd/package-2.0.xsd',
                     }
                 }
 
-                if (is_string($value) && $value && ($value{strlen($value) - 1} == "\n")) {
+                if (is_string($value) && $value && ($value[strlen($value) - 1] == "\n")) {
                     $value .= str_repeat($this->options['indent'], $this->_tagDepth);
                 }
                 $tmp .= $this->_createXMLTag(array(

--- a/PEAR/PackageFile/v1.php
+++ b/PEAR/PackageFile/v1.php
@@ -1575,7 +1575,7 @@ class PEAR_PackageFile_v1
             foreach ($methods as $method) {
                 $function = "$class::$method";
                 $key = "function;$function";
-                if ($method{0} == '_' || !strcasecmp($method, $class) ||
+                if ($method[0] == '_' || !strcasecmp($method, $class) ||
                     isset($this->_packageInfo['provides'][$key])) {
                     continue;
                 }
@@ -1586,7 +1586,7 @@ class PEAR_PackageFile_v1
 
         foreach ($srcinfo['declared_functions'] as $function) {
             $key = "function;$function";
-            if ($function{0} == '_' || isset($this->_packageInfo['provides'][$key])) {
+            if ($function[0] == '_' || isset($this->_packageInfo['provides'][$key])) {
                 continue;
             }
             if (!strstr($function, '::') && strncasecmp($function, $pn, $pnl)) {

--- a/PEAR/PackageFile/v2/Validator.php
+++ b/PEAR/PackageFile/v2/Validator.php
@@ -1080,8 +1080,8 @@ class PEAR_PackageFile_v2_Validator
             foreach ($list['file'] as $i => $file)
             {
                 if (isset($file['attribs']) && isset($file['attribs']['name'])) {
-                    if ($file['attribs']['name']{0} == '.' &&
-                          $file['attribs']['name']{1} == '/') {
+                    if ($file['attribs']['name'][0] == '.' &&
+                          $file['attribs']['name'][1] == '/') {
                         // name is something like "./doc/whatever.txt"
                         $this->_invalidFileName($file['attribs']['name'], $dirname);
                     }

--- a/PEAR/PackageFile/v2/Validator.php
+++ b/PEAR/PackageFile/v2/Validator.php
@@ -419,7 +419,7 @@ class PEAR_PackageFile_v2_Validator
             foreach ($tags as $i => $tag) {
                 if (!is_array($tag) || !isset($tag['attribs'])) {
                     foreach ($choice['attribs'] as $attrib) {
-                        if ($attrib{0} != '?') {
+                        if ($attrib[0] != '?') {
                             $ret &= $this->_tagHasNoAttribs($choice['tag'],
                                 $context);
                             continue 2;
@@ -427,7 +427,7 @@ class PEAR_PackageFile_v2_Validator
                     }
                 }
                 foreach ($choice['attribs'] as $attrib) {
-                    if ($attrib{0} != '?') {
+                    if ($attrib[0] != '?') {
                         if (!isset($tag['attribs'][$attrib])) {
                             $ret &= $this->_tagMissingAttribute($choice['tag'],
                                 $attrib, $context);
@@ -450,9 +450,9 @@ class PEAR_PackageFile_v2_Validator
             }
             return $ret;
         }
-        $multi = $key{0};
+        $multi = $key[0];
         if ($multi == '+' || $multi == '*') {
-            $ret['multiple'] = $key{0};
+            $ret['multiple'] = $key[0];
             $key = substr($key, 1);
         }
         if (count($attrs = explode('->', $key)) > 1) {
@@ -2106,7 +2106,7 @@ class PEAR_PackageFile_v2_Validator
             foreach ($methods as $method) {
                 $function = "$class::$method";
                 $key = "function;$function";
-                if ($method{0} == '_' || !strcasecmp($method, $class) ||
+                if ($method[0] == '_' || !strcasecmp($method, $class) ||
                     isset($providesret[$key])) {
                     continue;
                 }
@@ -2118,7 +2118,7 @@ class PEAR_PackageFile_v2_Validator
 
         foreach ($srcinfo['declared_functions'] as $function) {
             $key = "function;$function";
-            if ($function{0} == '_' || isset($providesret[$key])) {
+            if ($function[0] == '_' || isset($providesret[$key])) {
                 continue;
             }
 

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -2204,7 +2204,7 @@ class PEAR_Registry extends PEAR
             }
             if (!isset($components['scheme'])) {
                 if (strpos($components['path'], '/') !== false) {
-                    if ($components['path']{0} == '/') {
+                    if ($components['path'][0] == '/') {
                         return PEAR::raiseError('parsePackageName(): this is not ' .
                             'a package name, it begins with "/" in "' . $param . '"',
                             'invalid', null, null, $param);

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -1187,7 +1187,7 @@ class PEAR_Registry extends PEAR
 
         $dp = opendir($this->channelsdir);
         while ($ent = readdir($dp)) {
-            if ($ent{0} == '.' || substr($ent, -4) != '.reg') {
+            if ($ent[0] == '.' || substr($ent, -4) != '.reg') {
                 continue;
             }
 
@@ -1238,7 +1238,7 @@ class PEAR_Registry extends PEAR
         }
 
         while ($ent = readdir($dp)) {
-            if ($ent{0} == '.' || substr($ent, -4) != '.reg') {
+            if ($ent[0] == '.' || substr($ent, -4) != '.reg') {
                 continue;
             }
 
@@ -1262,7 +1262,7 @@ class PEAR_Registry extends PEAR
         }
 
         while ($ent = readdir($dp)) {
-            if ($ent{0} == '.' || substr($ent, -4) != '.reg') {
+            if ($ent[0] == '.' || substr($ent, -4) != '.reg') {
                 continue;
             }
             $pkglist[] = substr($ent, 0, -4);

--- a/PEAR/Start.php
+++ b/PEAR/Start.php
@@ -215,7 +215,7 @@ class PEAR_Start extends PEAR
 
         $potentials = array();
         while (false !== ($entry = readdir($dp))) {
-            if ($entry{0} == '.' || !in_array(substr($entry, -4), array('.tar', '.tgz'))) {
+            if ($entry[0] == '.' || !in_array(substr($entry, -4), array('.tar', '.tgz'))) {
                 continue;
             }
             $potentials[] = $entry;

--- a/PEAR/Start/CLI.php
+++ b/PEAR/Start/CLI.php
@@ -445,7 +445,7 @@ Thanks for using go-pear!
                 if (!strlen($dir)) {
                     continue;
                 }
-                if ($dir{strlen($dir) - 1} != '\\') {
+                if ($dir[strlen($dir) - 1] != '\\') {
                     $dir .= '\\';
                 }
                 $tmp = $dir . $program;

--- a/PEAR/Validate.php
+++ b/PEAR/Validate.php
@@ -209,7 +209,7 @@ class PEAR_Validate
                 }
                 $vlen = strlen($test);
                 $majver = substr($name, strlen($name) - $vlen);
-                while ($majver && !is_numeric($majver{0})) {
+                while ($majver && !is_numeric($majver[0])) {
                     $majver = substr($majver, 1);
                 }
                 if ($majver != $test) {
@@ -328,7 +328,7 @@ class PEAR_Validate
                 } else {
                     $vlen = strlen($versioncomponents[0] . '');
                     $majver = substr($name, strlen($name) - $vlen);
-                    while ($majver && !is_numeric($majver{0})) {
+                    while ($majver && !is_numeric($majver[0])) {
                         $majver = substr($majver, 1);
                     }
                     if (($versioncomponents[0] != 0) && $majver != $versioncomponents[0]) {
@@ -398,7 +398,7 @@ class PEAR_Validate
                 if ($this->_packagexml->getExtends()) {
                     $vlen = strlen($versioncomponents[0] . '');
                     $majver = substr($name, strlen($name) - $vlen);
-                    while ($majver && !is_numeric($majver{0})) {
+                    while ($majver && !is_numeric($majver[0])) {
                         $majver = substr($majver, 1);
                     }
                     if (($versioncomponents[0] != 0) && $majver != $versioncomponents[0]) {

--- a/PEAR/Validate.php
+++ b/PEAR/Validate.php
@@ -287,7 +287,7 @@ class PEAR_Validate
                 }
                 if (!$this->_packagexml->getExtends()) {
                     if ($versioncomponents[0] == '1') {
-                        if ($versioncomponents[2]{0} == '0') {
+                        if ($versioncomponents[2][0] == '0') {
                             if ($versioncomponents[2] == '0') {
                                 // version 1.*.0000
                                 $this->_addWarning('version',
@@ -339,7 +339,7 @@ class PEAR_Validate
                         return true;
                     }
                     if ($versioncomponents[0] == $majver) {
-                        if ($versioncomponents[2]{0} == '0') {
+                        if ($versioncomponents[2][0] == '0') {
                             if ($versioncomponents[2] == '0') {
                                 // version 2.*.0000
                                 $this->_addWarning('version',

--- a/System.php
+++ b/System.php
@@ -265,7 +265,7 @@ class System
             } elseif ($opt[0] == 'm') {
                 // if the mode is clearly an octal number (starts with 0)
                 // convert it to decimal
-                if (strlen($opt[1]) && $opt[1]{0} == '0') {
+                if (strlen($opt[1]) && $opt[1][0] == '0') {
                     $opt[1] = octdec($opt[1]);
                 } else {
                     // convert to int

--- a/System.php
+++ b/System.php
@@ -74,7 +74,7 @@ class System
             $offset = 0;
             foreach ($av as $a) {
                 $b = trim($a[0]);
-                if ($b{0} == '"' || $b{0} == "'") {
+                if ($b[0] == '"' || $b[0] == "'") {
                     continue;
                 }
 

--- a/make-gopear-phar.php
+++ b/make-gopear-phar.php
@@ -40,7 +40,7 @@ if ($dp === false) {
 
 $packages = array();
 foreach ($dp as $entry) {
-    if ($entry{0} == '.' || !in_array(substr($entry, -4), array('.tar'))) {
+    if ($entry[0] == '.' || !in_array(substr($entry, -4), array('.tar'))) {
         continue;
     }
 

--- a/make-installpear-nozlib-phar.php
+++ b/make-installpear-nozlib-phar.php
@@ -40,7 +40,7 @@ if ($dp === false) {
 
 $packages = array();
 foreach ($dp as $entry) {
-    if ($entry{0} == '.' || !in_array(substr($entry, -4), array('.tar'))) {
+    if ($entry[0] == '.' || !in_array(substr($entry, -4), array('.tar'))) {
         continue;
     }
 

--- a/make-pear-bundle.php
+++ b/make-pear-bundle.php
@@ -31,11 +31,11 @@ function extract_file_from_tarball($pkg, $filename, $dest_dir) /* {{{ */
 			break;
 		$checksum = 0;
 		for ($i = 0; $i < 148; $i++)
-			$checksum += ord($hdr_data{$i});
+			$checksum += ord($hdr_data[$i]);
 		for ($i = 148; $i < 156; $i++)
 			$checksum += 32;
 		for ($i = 156; $i < 512; $i++)
-			$checksum += ord($hdr_data{$i});
+			$checksum += ord($hdr_data[$i]);
 
 		$hdr = unpack("a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/a8checksum/a1typeflag/a100link/a6magic/a2version/a32uname/a32gname/a8devmajor/a8devminor", $hdr_data);
 


### PR DESCRIPTION
Deprecated: Array and string offset access syntax with curly braces is deprecated

Hopefully these are all (or most) of them:
```
[Clover@Clover-NB pear-core](fix-deprecation-curly-braces)$ rg -tphp "(\\$|->|::)[A-Za-z0-9_]+\{"
make-gopear-phar.php:43:    if ($entry{0} == '.' || !in_array(substr($entry, -4), array('.tar'))) {
make-installpear-nozlib-phar.php:43:    if ($entry{0} == '.' || !in_array(substr($entry, -4), array('.tar'))) {
make-pear-bundle.php:34:                        $checksum += ord($hdr_data{$i});
make-pear-bundle.php:38:                        $checksum += ord($hdr_data{$i});
System.php:77:                if ($b{0} == '"' || $b{0} == "'") {
OS\Guess.php:256:                if ($line{0} == '#' || trim($line) == '') {
PEAR\Builder.php:194:            if ($ent{0} == '.')
PEAR\Command.php:236:            if ($file{0} == '.' || substr($file, -4) != '.xml') {
PEAR\Common.php:689:                if ($method{0} == '_' || !strcasecmp($method, $class) ||
PEAR\Common.php:701:            if ($function{0} == '_' || isset($this->pkginfo['provides'][$key])) {
PEAR\Config.php:2095:                } elseif ($prepend{0} != '\\') {
PEAR\PackageFile.php:97:        if (!in_array($version{0}, array('1', '2'))) {
PEAR\PackageFile.php:102:        include_once 'PEAR/PackageFile/Parser/v' . $version{0} . '.php';
PEAR\PackageFile.php:103:        $version = $version{0};
PEAR\PackageFile.php:125:        if (!in_array($version{0}, array('1', '2'))) {
PEAR\PackageFile.php:130:        include_once 'PEAR/PackageFile/v' . $version{0} . '.php';
PEAR\PackageFile.php:131:        $version = $version{0};
PEAR\Downloader.php:1159:                } elseif ($prepend{0} != '\\') {
PEAR\Validate.php:212:                while ($majver && !is_numeric($majver{0})) {
PEAR\Validate.php:331:                    while ($majver && !is_numeric($majver{0})) {
PEAR\Validate.php:401:                    while ($majver && !is_numeric($majver{0})) {
PEAR\DependencyDB.php:177:        if ($depdb['_version']{0} > $this->_version{0}) {
PEAR\Start.php:218:            if ($entry{0} == '.' || !in_array(substr($entry, -4), array('.tar', '.tgz'))) {
PEAR\Command\Config.php:318:        if ($root{0} != '/') {
PEAR\Command\Config.php:341:        if ($root{strlen($root) - 1} == '/') {
PEAR\Registry.php:1190:            if ($ent{0} == '.' || substr($ent, -4) != '.reg') {
PEAR\Registry.php:1241:            if ($ent{0} == '.' || substr($ent, -4) != '.reg') {
PEAR\Registry.php:1265:            if ($ent{0} == '.' || substr($ent, -4) != '.reg') {
PEAR\Installer\Role.php:240:            if ($entry{0} == '.' || substr($entry, -4) != '.xml') {
PEAR\PackageFile\v1.php:1578:                if ($method{0} == '_' || !strcasecmp($method, $class) ||
PEAR\PackageFile\v1.php:1589:            if ($function{0} == '_' || isset($this->_packageInfo['provides'][$key])) {
PEAR\Start\CLI.php:448:                if ($dir{strlen($dir) - 1} != '\\') {
PEAR\PackageFile\Generator\v2.php:784:                if (is_string($value) && $value && ($value{strlen($value) - 1} == "\n")) {
PEAR\PackageFile\Generator\v1.php:907:                if ($platform{0} != '!') {
PEAR\PackageFile\Generator\v1.php:916:                    if ($os{0} == '!') {
PEAR\PackageFile\Generator\v1.php:1013:                        if ($platform{0} != '!' && $platform != $os) {
PEAR\PackageFile\v2\Validator.php:422:                        if ($attrib{0} != '?') {
PEAR\PackageFile\v2\Validator.php:430:                    if ($attrib{0} != '?') {
PEAR\PackageFile\v2\Validator.php:453:        $multi = $key{0};
PEAR\PackageFile\v2\Validator.php:455:            $ret['multiple'] = $key{0};
PEAR\PackageFile\v2\Validator.php:2109:                if ($method{0} == '_' || !strcasecmp($method, $class) ||
PEAR\PackageFile\v2\Validator.php:2121:            if ($function{0} == '_' || isset($providesret[$key])) {
```

https://github.com/php/php-src/blob/0e6e2297fcb27103cc5d550ee8434680ff1e879e/UPGRADING#L356-L357

---

**UPDATE**: 20190904 - Add more fixes.

```
[Clover@Clover-NB pear-core](fix-deprecation-curly-braces)$ rg -tphp "(\])\{"
System.php:268:                if (strlen($opt[1]) && $opt[1]{0} == '0') {
PEAR\DependencyDB.php:177:        if ($depdb['_version']{0} > $this->_version[0]) {
[SKIP] PEAR\Downloader.php:1667:            } elseif (preg_match('|^HTTP/1.[01] ([0-9]{3}) |', $line, $matches)) {
PEAR\Installer.php:228:            if (strlen($atts['platform']) && $atts['platform']{0} == '!') {
[SKIP] PEAR\Proxy.php:77:            if (preg_match('|^HTTP/1.[01] ([0-9]{3}) |', $line, $matches)) {
PEAR\Registry.php:2207:                    if ($components['path']{0} == '/') {
[SKIP] PEAR\REST.php:424:            } elseif (preg_match('|^HTTP/1.[01] ([0-9]{3}) |', $line, $matches)) {
PEAR\Command\Channels.php:676:        if (count($params) !== 2 || (!empty($params[1]) && $params[1]{0} == '-')) {
PEAR\Command\Common.php:149:                if ($info['arg']{0} == '(') {
PEAR\Validate.php:290:                        if ($versioncomponents[2]{0} == '0') {
PEAR\Validate.php:342:                        if ($versioncomponents[2]{0} == '0') {
PEAR\PackageFile\Generator\v1.php:892:                      $package['platform'][$file]{0} == '!') {
PEAR\PackageFile\Generator\v1.php:898:                      $package['platform'][$file]{0} != '!') {
PEAR\PackageFile\Generator\v1.php:962:                              $package['platform'][$file]{0} == '!') {
PEAR\PackageFile\Generator\v1.php:987:                              $package['platform'][$file]{0} != '!' &&
PEAR\PackageFile\v2\Validator.php:1083:                    if ($file['attribs']['name']{0} == '.' &&
PEAR\PackageFile\v2\Validator.php:1084:                          $file['attribs']['name']{1} == '/') {
```