### PR TITLE
Fix use of null/false as array

### DIFF
--- a/PEAR/Command/Remote.php
+++ b/PEAR/Command/Remote.php
@@ -222,7 +222,7 @@ parameter.
         }
 
         $installed = $reg->packageInfo($info['name'], null, $channel);
-        $info['installed'] = $installed['version'] ? $installed['version'] : '- no -';
+        $info['installed'] = $installed ? $installed['version'] : '- no -';
         if (is_array($info['installed'])) {
             $info['installed'] = $info['installed']['release'];
         }
@@ -351,7 +351,7 @@ parameter.
 
         foreach ($available as $name => $info) {
             $installed = $reg->packageInfo($name, null, $channel);
-            if (is_array($installed['version'])) {
+            if ($installed && is_array($installed['version'])) {
                 $installed['version'] = $installed['version']['release'];
             }
             $desc = $info['summary'];

--- a/PEAR/DependencyDB.php
+++ b/PEAR/DependencyDB.php
@@ -216,9 +216,11 @@ class PEAR_DependencyDB
         if (is_object($pkg)) {
             $channel = strtolower($pkg->getChannel());
             $package = strtolower($pkg->getPackage());
-        } else {
+        } else if (is_array($pkg)) {
             $channel = strtolower($pkg['channel']);
             $package = strtolower($pkg['package']);
+        } else {
+            return false;
         }
 
         $depend = $this->getDependentPackages($pkg);


### PR DESCRIPTION
This fixes a number of notices that are thrown on PHP 7.4.