### PR TITLE
Fix Travis builds on PHP 5.4 and 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ php:
   - 7.1
   - 7.0
   - 5.6
-  - 5.5
-  - 5.4
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: 7.3
+  include:
+    - php: 5.4
+      dist: precise
+    - php: 5.5
+      dist: trusty
+    
 install:
   - pear list
   - pear channel-update pear


### PR DESCRIPTION
Alternatively we can remove them altogether.