### PR TITLE
Fix documentation: the `--force` is required

### DIFF
--- a/README.CONTRIBUTING
+++ b/README.CONTRIBUTING
@@ -120,7 +120,7 @@ mkdir go-pear-tarballs
 cd go-pear-tarballs
 pear download -Z PEAR-stable Archive_Tar-stable Console_Getopt-stable XML_Util-stable
 cd ../..
-pear install PHP_Archive
+pear install --force PHP_Archive
 php make-installpear-nozlib-phar.php
 php make-gopear-phar.php
 


### PR DESCRIPTION
Without the `--force` option we get an error:

```
Failed to download pear/php_archive within preferred state "stable", latest release is version 0.12.0, stability "alpha", use "channel://pear.php.net/php_archive-0.12.0" to install
install failed
```