### PR TITLE
Fix logging error for urls not in cache

### DIFF
--- a/PEAR/REST.php
+++ b/PEAR/REST.php
@@ -178,7 +178,7 @@ class PEAR_REST
 
         $cachettl = $this->config->get('cache_ttl');
         // If cache is newer than $cachettl seconds, we use the cache!
-        if (time() - $cacheid['age'] < $cachettl) {
+        if (is_array($cacheid) && time() - $cacheid['age'] < $cachettl) {
             return $this->getCache($url);
         }
 


### PR DESCRIPTION
When a url is not in the cache, getCacheId will return 'false' but this is not caught before using cacheid['age'].

Notice: Trying to access array offset on value of type bool in PEAR/REST.php on line 181
PHP Notice: Trying to access array offset on value of type bool in /usr/share/php7/PEAR/PEAR/REST.php on line 181