### PR TITLE
Fix undefined constant name

### DIFF
--- a/PEAR/Builder.php
+++ b/PEAR/Builder.php
@@ -402,9 +402,9 @@ class PEAR_Builder extends PEAR_Common
                 }
                 if (substr($option['name'], 0, 5) === 'with-' &&
                     ($response === 'yes' || $response === 'autodetect')) {
-                    $configure_command .= " --{$option[name]}";
+                    $configure_command .= " --{$option['name']}";
                 } else {
-                    $configure_command .= " --{$option[name]}=".trim($response);
+                    $configure_command .= " --{$option['name']}=".trim($response);
                 }
             }
         }


### PR DESCRIPTION
fix this  warning.

```
enable igbinary serializer support? [no] :
Warning: Use of undefined constant name - assumed 'name' (this will throw an Error in a future version of PHP) in PEAR/Builder.php on line 407

Warning: Use of undefined constant name - assumed 'name' (this will throw an Error in a future version of PHP) in /usr/local/lib/php/PEAR/Builder.php on line 407
enable lzf compression support? [no] :
Warning: Use of undefined constant name - assumed 'name' (this will throw an Error in a future version of PHP) in PEAR/Builder.php on line 407

Warning: Use of undefined constant name - assumed 'name' (this will throw an Error in a future version of PHP) in /usr/local/lib/php/PEAR/Builder.php on line 407
enable zstd compression support? [no] :
Warning: Use of undefined constant name - assumed 'name' (this will throw an Error in a future version of PHP) in PEAR/Builder.php on line 407

Warning: Use of undefined constant name - assumed 'name' (this will throw an Error in a future version of PHP) in /usr/local/lib/php/PEAR/Builder.php on line 407
```