### PR TITLE
Sort list of packages

### DIFF
--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -1245,6 +1245,7 @@ class PEAR_Registry extends PEAR
             $pkglist[] = substr($ent, 0, -4);
         }
         closedir($dp);
+        sort($pkglist);
         return $pkglist;
     }
 


### PR DESCRIPTION
filesystem `readdir` order is non-deterministic
so the `.filemap` output was observed to have variations in ordering
across builds (in scratch VMs/FSes).

See https://reproducible-builds.org/ for why this matters.

Note: could not test this, because I could not get the
.phar file updated with this patch after an hour.

This patch was done while working on reproducible builds in openSUSE.