### PR TITLE
Adding ppc64le architecutre to support travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ php:
   - 7.1
   - 7.0
   - 5.6
+arch:
+  - ppc64le
+  - amd64
 
 jobs:
   fast_finish: true
@@ -18,6 +21,13 @@ jobs:
       dist: trusty
     - php: 5.4
       dist: precise
+  exclude:
+    - php: 5.5
+      dist: trusty
+      arch: ppc64le
+    - php: 5.4
+      dist: precise
+      arch: ppc64le
     
 install:
   - pear version


### PR DESCRIPTION
Hi,
I had added ppc64le architecture to run travis ci  and looks like its been successfully added. I believe it is ready for the final review and merge. As there is no support for php 5.4 and 5.5 for the ppc64le architecture, hence jobs are excluded for the same. 

Please have a look.

Thanks!!"