### PR TITLE
unsupported protocol - use --force to continue

### DIFF
--- a/PEAR/Downloader.php
+++ b/PEAR/Downloader.php
@@ -850,7 +850,7 @@ class PEAR_Downloader extends PEAR_Common
                !($base = $chan->getBaseURL('REST1.0', $preferred_mirror))
               )
         ) {
-            return $this->raiseError($parr['channel'] . ' is using a unsupported protocol - This should never happen.');
+            return $this->raiseError($parr['channel'] . ' is using an unsupported protocol - This should never happen. Use --force to continue');
         }
 
         if ($base2) {


### PR DESCRIPTION
This fixes a typo (an instead on a) and a possible solution.

maybe we can enhance the error output more somehow?