### PR TITLE
Add $this operator to _determineIfPowerpc calls

### DIFF
--- a/OS/Guess.php
+++ b/OS/Guess.php
@@ -153,10 +153,10 @@ class OS_Guess
                 $sysname = 'darwin';
                 $nodename = $parts[2];
                 $release = $parts[3];
-                $cpu = _determineIfPowerpc($cpu, $parts);
+                $cpu = $this->_determineIfPowerpc($cpu, $parts);
                 break;
             case 'Darwin' :
-                $cpu = _determineIfPowerpc($cpu, $parts);
+                $cpu = $this->_determineIfPowerpc($cpu, $parts);
                 $release = preg_replace('/^([0-9]+\.[0-9]+).*/', '\1', $parts[2]);
                 break;
             default:


### PR DESCRIPTION
This PR has a minor fix for the `OS_Guess` class.

Calling `_determineIfPowerpc` without `$this` operator leads to the following error on `macOS`.

```bash
Fatal error: Uncaught Error: Call to undefined function _determineIfPowerpc()
```

Error: https://3v4l.org/sog9H