### PR TITLE
Fix: Creation of dynamic property PEAR_Error::$callback is deprecated

### DIFF
--- a/PEAR.php
+++ b/PEAR.php
@@ -859,6 +859,7 @@ class PEAR_Error
     var $message              = '';
     var $userinfo             = '';
     var $backtrace            = null;
+    var $callback             = null;
 
     /**
      * PEAR_Error constructor


### PR DESCRIPTION
Discovered running Cache_Lite test suite, but may affects some others