### PR TITLE
Fixed extension loaded check for pecl binaries

### DIFF
--- a/PEAR/Installer.php
+++ b/PEAR/Installer.php
@@ -1529,11 +1529,11 @@ class PEAR_Installer extends PEAR_Downloader
         foreach ($built as $ext) {
             $bn = basename($ext['file']);
             list($_ext_name, $_ext_suff) = explode('.', $bn);
-            if ($_ext_suff == '.so' || $_ext_suff == '.dll') {
+            if ($_ext_suff == 'so' || $_ext_suff == 'dll') {
                 if (extension_loaded($_ext_name)) {
-                    $this->raiseError("Extension '$_ext_name' already loaded. " .
-                                      'Please unload it in your php.ini file ' .
-                                      'prior to install or upgrade');
+                    return $this->raiseError("Extension '$_ext_name' already loaded. " .
+                                             'Please unload it in your php.ini file ' .
+                                             'prior to install or upgrade');
                 }
                 $role = 'ext';
             } else {


### PR DESCRIPTION
This check is used to make sure we don't overwrite binary files that are already in use, as doing so will cause a segmentation fault. This is reported among others in https://bugs.xdebug.org/view.php?id=2167, but I have ran into this in many occasions.

However, this check never worked, since its introduction 19 years ago, as the `return` was missing, and the suffix as created by `basename` does not include the `.`.