### PR TITLE
Remove -n option from pecl.bat for shared extensions

### DIFF
--- a/scripts/pecl.bat
+++ b/scripts/pecl.bat
@@ -110,6 +110,6 @@ ECHO The current value is:
 ECHO %PHP_PEAR_PHP_BIN%
 GOTO END
 :RUN
-"%PHP_PEAR_PHP_BIN%" -C -n -d date.timezone=UTC -d output_buffering=1 -d safe_mode=0 -d "include_path='%PHP_PEAR_INSTALL_DIR%'" -d register_argc_argv="On" -d variables_order=EGPCS -f "%PHP_PEAR_INSTALL_DIR%\peclcmd.php" -- %1 %2 %3 %4 %5 %6 %7 %8 %9
+"%PHP_PEAR_PHP_BIN%" -C -d date.timezone=UTC -d output_buffering=1 -d safe_mode=0 -d "include_path='%PHP_PEAR_INSTALL_DIR%'" -d register_argc_argv="On" -d variables_order=EGPCS -f "%PHP_PEAR_INSTALL_DIR%\peclcmd.php" -- %1 %2 %3 %4 %5 %6 %7 %8 %9
 :END
 @ECHO ON


### PR DESCRIPTION
As described in f94454a74785865cec50bf9d64c410efc29b587a

> When PHP is using shared extensions:
>
> `./configure --with-openssl=shared --enable-xml=shared`
>
> The -n option in PHP command line (in the PECL shell script) removes them from being enabled and PECL script won't work ok anymore. This goes mainly for the xml and openssl PHP extensions which are needed to install PECL extensions via the https protocol and to parse XML files.

Unfortunately, the fix was only applied to `pecl.sh`, so the issue described in https://bugs.php.net/bug.php?id=77522 still occurs on Windows when built with shared extensions.

This PR applies the same fix to `pecl.bat` to avoid the issue on Windows.