### PR TITLE
Upgrade $php_errormsg to error_get_last()

### DIFF
--- a/PEAR/Command/Remote.php
+++ b/PEAR/Command/Remote.php
@@ -769,7 +769,13 @@ parameter.
         }
 
         if (!($dp = @opendir($cache_dir))) {
-            return $this->raiseError("opendir($cache_dir) failed: $php_errormsg");
+            $error = error_get_last();
+            if (is_array($error) && array_key_exists('message', $error)) {
+                $error_message = ": " . $error['message'];
+            } else {
+                $error_message = "";
+            }
+            return $this->raiseError("opendir($cache_dir) failed $error_message");
         }
 
         if ($verbose >= 1) {
@@ -784,7 +790,13 @@ parameter.
                     $ok = @unlink($path);
                 } else {
                     $ok = false;
-                    $php_errormsg = '';
+                }
+
+                $error = error_get_last();
+                if (is_array($error) && array_key_exists('message', $error)) {
+                    $error_message = $error['message'];
+                } else {
+                    $error_message = "";
                 }
 
                 if ($ok) {
@@ -793,7 +805,7 @@ parameter.
                     }
                     $num++;
                 } elseif ($verbose >= 1) {
-                    $output .= "failed to delete $path $php_errormsg\n";
+                    $output .= "failed to delete $path $error_message\n";
                 }
             }
         }

--- a/PEAR/Config.php
+++ b/PEAR/Config.php
@@ -1026,12 +1026,24 @@ class PEAR_Config extends PEAR
 
         $fp = @fopen($file, "w");
         if (!$fp) {
-            return $this->raiseError("PEAR_Config::writeConfigFile fopen('$file','w') failed ($php_errormsg)");
+            $error = error_get_last();
+            if (is_array($error) && array_key_exists('message', $error)) {
+                $error_message = "(" . $error['message'] . ")";
+            } else {
+                $error_message = "";
+            }
+            return $this->raiseError("PEAR_Config::writeConfigFile fopen('$file','w') failed ($error_message)");
         }
 
         $contents = "#PEAR_Config 0.9\n" . serialize($data);
         if (!@fwrite($fp, $contents)) {
-            return $this->raiseError("PEAR_Config::writeConfigFile: fwrite failed ($php_errormsg)");
+            $error = error_get_last();
+            if (is_array($error) && array_key_exists('message', $error)) {
+                $error_message = "(" . $error['message'] . ")";
+            } else {
+                $error_message = "";
+            }
+            return $this->raiseError("PEAR_Config::writeConfigFile: fwrite failed $error_message");
         }
         return true;
     }

--- a/PEAR/DependencyDB.php
+++ b/PEAR/DependencyDB.php
@@ -501,9 +501,13 @@ class PEAR_DependencyDB
         }
 
         if (!is_resource($this->_lockFp)) {
-            $last_errormsg = error_get_last();
-            return PEAR::raiseError("could not create Dependency lock file" .
-                                     (isset($last_errormsg) ? ": " . $last_errormsg : ""));
+            $error = error_get_last();
+            if (is_array($error) && array_key_exists('message', $error)) {
+                $error_message = ": " . $error['message'];
+            } else {
+                $error_message = "";
+            }
+            return PEAR::raiseError("could not create Dependency lock file $error_message ");
         }
 
         if (!(int)flock($this->_lockFp, $mode)) {

--- a/PEAR/PackageFile/v2/Validator.php
+++ b/PEAR/PackageFile/v2/Validator.php
@@ -1870,7 +1870,11 @@ class PEAR_PackageFile_v2_Validator
 
         // Silence this function so we can catch PHP Warnings and show our own custom message
         $tokens = @token_get_all($contents);
-        if (isset($php_errormsg)) {
+        $error = error_get_last();
+        if (is_array($error) && array_key_exists('message', $error)) {
+            $error_message = $error['message'];
+        }
+        if (isset($error_message)) {
             if (isset($this->_stack)) {
                 $pn = $this->_pf->getPackage();
                 $this->_stack->push(__FUNCTION__, 'warning',

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -780,8 +780,13 @@ class PEAR_Registry extends PEAR
 
         $fp = @fopen($this->filemap, 'r');
         if (!$fp) {
-            $last_errormsg = error_get_last();
-            return $this->raiseError('PEAR_Registry: could not open filemap "' . $this->filemap . '"', PEAR_REGISTRY_ERROR_FILE, null, null, $last_errormsg);
+            $error = error_get_last();
+            if (is_array($error) && array_key_exists('message', $error)) {
+                $error_message = $error['message'];
+            } else {
+                $error_message = "";
+            }
+            return $this->raiseError('PEAR_Registry: could not open filemap "' . $this->filemap . '"', PEAR_REGISTRY_ERROR_FILE, null, null, $error_message);
         }
 
         clearstatcache();
@@ -843,8 +848,13 @@ class PEAR_Registry extends PEAR
 
         if (!is_resource($this->lock_fp)) {
             $this->lock_fp = null;
-            return $this->raiseError("could not create lock file" .
-                                     (isset($php_errormsg) ? ": " . $php_errormsg : ""));
+            $error = error_get_last();
+            if (is_array($error) && array_key_exists($error, 'message')) {
+                $error_message = ":" . $error['message'];
+            } else {
+                $error_message = "";
+            }
+            return $this->raiseError("could not create lock file $error_message");
         }
 
         if (!(int)flock($this->lock_fp, $mode)) {

--- a/tests/PEAR_Installer/ftp_test_files/FTP.php.inc
+++ b/tests/PEAR_Installer/ftp_test_files/FTP.php.inc
@@ -272,7 +272,13 @@ class test_PEAR_RemoteInstaller extends PEAR_RemoteInstaller {
         if (!$wp = @fopen($dest_file, 'wb')) {
             fclose($fp);
             if ($callback) {
-                call_user_func($callback, 'writefailed', array($dest_file, $php_errormsg));
+                $error = error_get_last();
+                if (is_array($error) && array_key_exists('message', $error)) {
+                    $error_message = $error['message'];
+                } else {
+                    $error_message = "";
+                }
+                call_user_func($callback, 'writefailed', array($dest_file, $error_message));
             }
             return PEAR::raiseError("could not open $dest_file for writing");
         }
@@ -294,10 +300,16 @@ class test_PEAR_RemoteInstaller extends PEAR_RemoteInstaller {
                 call_user_func($callback, 'bytesread', $bytes);
             }
             if (!@fwrite($wp, $data)) {
-                if ($callback) {
-                    call_user_func($callback, 'writefailed', array($dest_file, $php_errormsg));
+                $error = error_get_last();
+                if (is_array($error) && array_key_exists('message', $error)) {
+                    $error_message = $error['message'];
+                } else {
+                    $error_message = "";
                 }
-                return PEAR::raiseError("$dest_file: write failed ($php_errormsg)");
+                if ($callback) {
+                    call_user_func($callback, 'writefailed', array($dest_file, $error_message));
+                }
+                return PEAR::raiseError("$dest_file: write failed ($error_message)");
             }
         }
         fclose($wp);

--- a/tests/download_test_classes.php.inc
+++ b/tests/download_test_classes.php.inc
@@ -223,7 +223,13 @@ class test_PEAR_Installer extends PEAR_Installer {
         if (!$wp = @fopen($dest_file, 'wb')) {
             fclose($fp);
             if ($callback) {
-                call_user_func($callback, 'writefailed', array($dest_file, $php_errormsg));
+                $error = error_get_last();
+                if (is_array($error) && array_key_exists('message', $error)) {
+                    $error_message = $error['message'];
+                } else {
+                    $error_message = "";
+                }
+                call_user_func($callback, 'writefailed', array($dest_file, $error_message));
             }
             return PEAR::raiseError("could not open $dest_file for writing");
         }
@@ -245,10 +251,16 @@ class test_PEAR_Installer extends PEAR_Installer {
                 call_user_func($callback, 'bytesread', $bytes);
             }
             if (!@fwrite($wp, $data)) {
-                if ($callback) {
-                    call_user_func($callback, 'writefailed', array($dest_file, $php_errormsg));
+                $error = error_get_last();
+                if (is_array($error) && array_key_exists('message', $error)) {
+                    $error_message = $error['message'];
+                } else {
+                    $error_message = "";
                 }
-                return PEAR::raiseError("$dest_file: write failed ($php_errormsg)");
+                if ($callback) {
+                    call_user_func($callback, 'writefailed', array($dest_file, $error_message));
+                }
+                return PEAR::raiseError("$dest_file: write failed ($error_message)");
             }
         }
         fclose($wp);
@@ -413,8 +425,14 @@ class test_PEAR_Downloader extends PEAR_Downloader {
 
         $dest_file = $save_dir . DIRECTORY_SEPARATOR . $save_as;
         if (!$wp = @fopen($dest_file, 'wb')) {
+            $error = error_get_last();
+            if (is_array($error) && array_key_exists('message', $error)) {
+                $error_message = $error['message'];
+            } else {
+                $error_message = "";
+            }
             if ($callback) {
-                call_user_func($callback, 'writefailed', array($dest_file, $php_errormsg));
+                call_user_func($callback, 'writefailed', array($dest_file, $error_message));
             }
             return PEAR::raiseError("could not open $dest_file for writing");
         }
@@ -436,10 +454,16 @@ class test_PEAR_Downloader extends PEAR_Downloader {
                 call_user_func($callback, 'bytesread', $bytes);
             }
             if (!@fwrite($wp, $data)) {
-                if ($callback) {
-                    call_user_func($callback, 'writefailed', array($dest_file, $php_errormsg));
+                $error = error_get_last();
+                if (is_array($error) && array_key_exists('message', $error)) {
+                    $error_message = $error['message'];
+                } else {
+                    $error_message = "";
                 }
-                return PEAR::raiseError("$dest_file: write failed ($php_errormsg)");
+                if ($callback) {
+                    call_user_func($callback, 'writefailed', array($dest_file, $error_message));
+                }
+                return PEAR::raiseError("$dest_file: write failed ($error_message)");
             }
         }
         fclose($wp);


### PR DESCRIPTION
The `$php_errormsg` is deprecated as of PHP 7.2.0. The error_get_last() should be used instead.