### PR TITLE
Fix bug #27796: "Array to string" conversion warnings on installs/other actions

### DIFF
--- a/PEAR/DependencyDB.php
+++ b/PEAR/DependencyDB.php
@@ -501,7 +501,7 @@ class PEAR_DependencyDB
         }
 
         if (!is_resource($this->_lockFp)) {
-            $last_errormsg = error_get_last();
+            $last_errormsg = error_get_last()["message"];
             return PEAR::raiseError("could not create Dependency lock file" .
                                      (isset($last_errormsg) ? ": " . $last_errormsg : ""));
         }

--- a/PEAR/Registry.php
+++ b/PEAR/Registry.php
@@ -780,7 +780,7 @@ class PEAR_Registry extends PEAR
 
         $fp = @fopen($this->filemap, 'r');
         if (!$fp) {
-            $last_errormsg = error_get_last();
+            $last_errormsg = error_get_last()["message"];
             return $this->raiseError('PEAR_Registry: could not open filemap "' . $this->filemap . '"', PEAR_REGISTRY_ERROR_FILE, null, null, $last_errormsg);
         }
 


### PR DESCRIPTION
Fixes a bug introduced in commit 61ffb66 which triggers "array to string" conversion warnings on various actions