### PR TITLE
Never reference E_STRICT on PHP 8.4+

### DIFF
--- a/PEAR/RunTest.php
+++ b/PEAR/RunTest.php
@@ -88,7 +88,11 @@ class PEAR_RunTest
         if (!defined('E_STRICT')) {
             define('E_STRICT', 0);
         }
-        $this->ini_overwrites[] = 'error_reporting=' . (E_ALL & ~(E_DEPRECATED | E_STRICT));
+        $excluded_error_reporting = E_DEPRECATED;
+        if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 80400) {
+            $excluded_error_reporting |= E_STRICT;
+        }
+        $this->ini_overwrites[] = 'error_reporting=' . (E_ALL & ~$excluded_error_reporting);
         if (is_null($logger)) {
             require_once 'PEAR/Common.php';
             $logger = new PEAR_Common;

--- a/make-gopear-phar.php
+++ b/make-gopear-phar.php
@@ -22,7 +22,12 @@
  * @copyright  2005-2009 The Authors
  * @license    http://opensource.org/licenses/bsd-license.php New BSD License
  */
-error_reporting(error_reporting() & ~E_STRICT & ~E_DEPRECATED);
+$new_error_reporting = error_reporting() & ~E_DEPRECATED;
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 80400) {
+    $new_error_reporting &= ~E_STRICT;
+}
+error_reporting($new_error_reporting);
+unset($new_error_reporting);
 
 function replaceVersion($contents, $path)
 {

--- a/make-installpear-nozlib-phar.php
+++ b/make-installpear-nozlib-phar.php
@@ -22,7 +22,12 @@
  * @copyright  2005-2009 The Authors
  * @license    http://opensource.org/licenses/bsd-license.php New BSD License
  */
-error_reporting(error_reporting() & ~E_STRICT & ~E_DEPRECATED);
+$new_error_reporting = error_reporting() & ~E_DEPRECATED;
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 80400) {
+    $new_error_reporting &= ~E_STRICT;
+}
+error_reporting($new_error_reporting);
+unset($new_error_reporting);
 
 function replaceVersion($contents, $path)
 {

--- a/scripts/pearcmd.php
+++ b/scripts/pearcmd.php
@@ -438,7 +438,7 @@ function cmdHelp($command)
  */
 function error_handler($errno, $errmsg, $file, $line)
 {
-    if ($errno & E_STRICT) {
+    if ((!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 80400) && ($errno & E_STRICT)) {
         return; // E_STRICT
     }
     if ($errno & E_DEPRECATED) {
@@ -455,7 +455,6 @@ function error_handler($errno, $errmsg, $file, $line)
         E_ERROR   =>  "Error",
         E_WARNING   =>  "Warning",
         E_PARSE   =>  "Parsing Error",
-        E_STRICT  => 'Strict Warning',
         E_NOTICE   =>  "Notice",
         E_CORE_ERROR  =>  "Core Error",
         E_CORE_WARNING  =>  "Core Warning",
@@ -465,6 +464,9 @@ function error_handler($errno, $errmsg, $file, $line)
         E_USER_WARNING =>  "User Warning",
         E_USER_NOTICE =>  "User Notice"
     );
+    if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 80400) {
+        $errortype[E_STRICT] = 'Strict Warning';
+    }
     $prefix = $errortype[$errno];
     global $_PEAR_PHPDIR;
     if (stristr($file, $_PEAR_PHPDIR)) {

--- a/tests/PEAR_Error/pear_error.phpt
+++ b/tests/PEAR_Error/pear_error.phpt
@@ -15,7 +15,7 @@ if (!getenv('PHP_PEAR_RUNTESTS')) {
 
 include_once "PEAR.php";
 
-if (!defined('E_STRICT')) {
+if ((!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 80400) && !defined('E_STRICT')) {
     define('E_STRICT', -1);
 }
 if (!defined('E_DEPRECATED')) {
@@ -23,7 +23,7 @@ if (!defined('E_DEPRECATED')) {
 }
 
 function test_error_handler($errno, $errmsg, $file, $line) {
-    if ($errno == E_STRICT) {
+    if ((!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 80400) && $errno == E_STRICT) {
         return;
     }
     if ($errno == E_DEPRECATED) {


### PR DESCRIPTION
See https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant

Close https://github.com/pear/pear-core/issues/144