### PR TITLE
Add GH Action that builds PHAR files with build-release.sh

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 as of 2024-12-19
         name: Checkout repository
       -
         name: Setup PHP
@@ -69,7 +69,7 @@ jobs:
       -
         name: Upload artifacts
         if: github.event_name != 'release'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0 as of 2024-12-19
         with:
           name: PHAR files
           path: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -64,6 +64,9 @@ jobs:
       -
         run: sha512sum install-pear-nozlib.phar >install-pear-nozlib.phar.sha512
       -
+        name: Dump SHA-512 checksums
+        run: cat *.phar.sha512
+      -
         name: Upload artifacts
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Checkout repository
       -
         name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1 as of 2024-12-18
         with:
           php-version: ${{ env.PHP_VERSION }}
           coverage: none

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,83 @@
+name: Build Release
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags-ignore:
+      - "**"
+  pull_request:
+    branches:
+      - main
+      - master
+  release:
+    types:
+      - published
+
+env:
+  PHP_VERSION: 5.4
+
+jobs:
+  build-release:
+    name: Build Release
+    runs-on: ubuntu-latest
+    steps:
+      -
+        uses: actions/checkout@v4
+        name: Checkout repository
+      -
+        name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          coverage: none
+          ini-values: include_path=/usr/local/php/${{ env.PHP_VERSION }}/share/pear
+      -
+        name: Install PEAR
+        run: |
+          sudo apt-get install --fix-broken
+          sudo apt-get install -qy php-pear
+      -
+        name: Update PEAR
+        run: |
+          pear channel-update pear
+          pear upgrade -f pear
+      -
+        name: Install PEAR dependencies
+        run: |
+          pear upgrade --force archive_tar console_getopt php_archive
+      -
+        name: PEAR config
+        run: pear config-show
+      -
+        name: PEAR list
+        run: pear list
+      -
+        name: PHP modules
+        run: php -m
+      -
+        name: Build release
+        run: ./build-release.sh
+      -
+        run: sha512sum go-pear.phar >go-pear.phar.sha512
+      -
+        run: sha512sum install-pear-nozlib.phar >install-pear-nozlib.phar.sha512
+      -
+        name: Upload artifacts
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v4
+        with:
+          name: PHAR files
+          path: |
+            ./go-pear.phar
+            ./go-pear.phar.sha512
+            ./install-pear-nozlib.phar
+            ./install-pear-nozlib.phar.sha512
+          if-no-files-found: error
+      -
+        name: Attach release assets
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.event.release.tag_name }} go-pear.phar go-pear.phar.sha512 install-pear-nozlib.phar install-pear-nozlib.phar.sha512

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,11 +42,11 @@ jobs:
         name: Update PEAR
         run: |
           pear channel-update pear
-          pear upgrade -f pear
+          pear upgrade --force pear-stable
       -
         name: Install PEAR dependencies
         run: |
-          pear upgrade --force archive_tar console_getopt php_archive
+          pear upgrade --force archive_tar-stable console_getopt-stable php_archive-stable
       -
         name: PEAR config
         run: pear config-show


### PR DESCRIPTION
People may install pear in two ways (AFAIK):

1. By using the https://pear.php.net/install-pear-nozlib.phar file (for example [PHP uses it](https://github.com/php/php-src/blob/php-8.4.1/pear/Makefile.frag#L10C22-L11C1))
2. By using https://pear.php.net/go-pear.phar (as [described in the manual](https://pear.php.net/manual/en/installation.getting.php#installation.getting.unix))

What about adding a GitHub Action that generates those two PHAR files (and attaches them to GitHub Releases autimatically when someone publishes a [new release](https://github.com/pear/pear-core/releases)).

We'd also need to update the two PHARs on the pear.php.net website, but at least we don't have to compile them manually.