### PR TITLE
Fix HTTP chunked encoding handling

### DIFF
--- a/PEAR/REST.php
+++ b/PEAR/REST.php
@@ -448,8 +448,19 @@ class PEAR_REST
         $length = isset($headers['content-length']) ? $headers['content-length'] : -1;
 
         $data = '';
-        while ($chunk = @fread($fp, 8192)) {
-            $data .= $chunk;
+        if (isset($headers['transfer-encoding']) && strtolower($headers['transfer-encoding']) === 'chunked') {
+            while (!feof($fp)) {
+                $chunk_size = hexdec(fgets($fp));
+                if ($chunk_size === 0) {
+                    break;
+                }
+                $data .= fread($fp, $chunk_size);
+                fgets($fp); // Skip the trailing CRLF
+            }
+        } else {
+            while ($chunk = @fread($fp, 8192)) {
+                $data .= $chunk;
+            }
         }
         fclose($fp);
 


### PR DESCRIPTION
Fixes #151

Update `PEAR/REST.php` and `PEAR/Downloader.php` to handle HTTP chunked encoding responses properly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pear/pear-core/pull/152?shareId=afeeeb2e-a94c-4251-a5ba-4e3da3841222).