### PR TITLE
Throw `new Error` instead of E_USER_ERROR on PHP 7.0+

### DIFF
--- a/PEAR.php
+++ b/PEAR.php
@@ -216,9 +216,13 @@ class PEAR
     public function __call($method, $arguments)
     {
         if (!isset(self::$bivalentMethods[$method])) {
-            trigger_error(
-                'Call to undefined method PEAR::' . $method . '()', E_USER_ERROR
-            );
+           if (PHP_VERSION_ID < 70000) {
+                trigger_error(
+                    'Call to undefined method PEAR::' . $method . '()', E_USER_ERROR
+                );
+            } else {
+                throw new Error('Call to undefined method PEAR::' . $method . '()');
+            }
         }
         return call_user_func_array(
             array(__CLASS__, '_' . $method),
@@ -229,9 +233,13 @@ class PEAR
     public static function __callStatic($method, $arguments)
     {
         if (!isset(self::$bivalentMethods[$method])) {
-            trigger_error(
-                'Call to undefined method PEAR::' . $method . '()', E_USER_ERROR
-            );
+            if (PHP_VERSION_ID < 70000) {
+                trigger_error(
+                    'Call to undefined method PEAR::' . $method . '()', E_USER_ERROR
+                );
+            } else {
+                throw new Error('Call to undefined method PEAR::' . $method . '()');
+            }
         }
         return call_user_func_array(
             array(__CLASS__, '_' . $method),

--- a/PEAR/Frontend/CLI.php
+++ b/PEAR/Frontend/CLI.php
@@ -357,7 +357,11 @@ class PEAR_Frontend_CLI extends PEAR_Frontend
 
     function userConfirm($prompt, $default = 'yes')
     {
-        trigger_error("PEAR_Frontend_CLI::userConfirm not yet converted", E_USER_ERROR);
+        if (PHP_VERSION_ID < 70000) {
+            trigger_error("PEAR_Frontend_CLI::userConfirm not yet converted", E_USER_ERROR);
+        } else {
+            throw new Error('PEAR_Frontend_CLI::userConfirm not yet converted');
+        }
         static $positives = array('y', 'yes', 'on', '1');
         static $negatives = array('n', 'no', 'off', '0');
         print "$this->lp$prompt [$default] : ";


### PR DESCRIPTION
Calling trigger_error with E_USER_ERROR was the idiom in PHP 5.x for fatal errors that were (theoretically) recoverable but not meant to be caught by generic `catch (Exception $e)` statements.

Since PHP 7.0, this has been obsoleted by the Throwable interface and the new Error class, which sits outside the Exception hierarchy.

Internal use, such as for calling an undefined method, also throw `Error` since PHP 7.0 (<https://3v4l.org/Y9bFm>), and calling trigger_error with E_USER_ERROR emits a deprecation warning as of PHP 8.4.0.

Since this project supports PHP 5.6+, the old code is kept under a <7.0 condition.

The PHP_VERSION_ID constant is available since PHP 5.2.7 (<https://3v4l.org/ifWRP>).

Fixes https://github.com/pear/pear-core/issues/155.