### PR TITLE
add message about PECL deprecated by PIE

### DIFF
--- a/scripts/pearcmd.php
+++ b/scripts/pearcmd.php
@@ -360,6 +360,11 @@ function usage($error = null, $helpsubject = null)
             "Type \"$progname help <command>\" to get the help ".
             "for the specified command.";
     }
+    if (PEAR_RUNTYPE === 'pecl'&& in_array($helpsubject, array(null, 'install', 'upgrade'))) {
+        $put .=
+            "\nNotice: PECL is now deprecated. " .
+            "PHP Installer for Extensions (PIE) is the replacement for PECL.";
+    }
     fputs($stdout, "$put\n");
     fclose($stdout);
 

--- a/scripts/pearcmd.php
+++ b/scripts/pearcmd.php
@@ -360,7 +360,9 @@ function usage($error = null, $helpsubject = null)
             "Type \"$progname help <command>\" to get the help ".
             "for the specified command.";
     }
-    if (PEAR_RUNTYPE === 'pecl'&& in_array($helpsubject, array(null, 'install', 'upgrade'))) {
+    if (PEAR_RUNTYPE === 'pecl'
+        && version_compare(PHP_VERSION, '8.1') > 0
+        && in_array($helpsubject, array(null, 'download', 'install', 'upgrade', 'upgrade-all'))) {
         $put .=
             "\nNotice: PECL is now deprecated. " .
             "PHP Installer for Extensions (PIE) is the replacement for PECL.";


### PR DESCRIPTION
Additional message when invoked as

- `pecl help`
- `pecl help install`
- `pecl help upgrade`

`pear` and other commands have not changed (`download` and `upgrade-all` may be candidates)